### PR TITLE
Fixed typset problem with unreplaced ADOC variables

### DIFF
--- a/adoc/SLES4SAP-hana-scaleOut-PerfOpt-12.adoc
+++ b/adoc/SLES4SAP-hana-scaleOut-PerfOpt-12.adoc
@@ -668,7 +668,7 @@ Create _/etc/fstab_ entries for the three NFS pools
 
 In the sample environment those lines are as follows:
 
-[subs="specialchars,attributes,quotes"]
+[subs="specialchars,attributes"]
 ----
 {myNFSSharedSite1}  /hana/data/{SID}      nfs4  defaults  0 0
 {myNFSDataSite1}  /hana/shared/{SID}    nfs4  defaults  0 0
@@ -906,7 +906,7 @@ USER           PID  ...  COMMAND
 {mysidlc}adm         6635 ...    \_ /bin/sh /usr/sap/{sid}/HDB{inst}/HDB info
 {mysidlc}adm         6658 ...        \_ ps fx -U {sid} -o user,pid,ppid,pcpu,vsz,rss,args
 {mysidlc}adm         5442 ...  sapstart pf=/hana/shared/{sid}/profile/{sid}_HDB{inst}_{mySite1FirstNode}
-{mysidlc}adm         5456 ...   \_ /usr/sap/{sid}/HDB{inst}/{mySite1FirstNode}/trace/hdb.sap{sidlc}_HDB{inst} -d -nw -f /usr/sap/{mysidlc}/HDB{inst}/suse
+{mysidlc}adm         5456 ...   \_ /usr/sap/{sid}/HDB{inst}/{mySite1FirstNode}/trace/hdb.sap{mysidlc}_HDB{inst} -d -nw -f /usr/sap/{mysidlc}/HDB{inst}/suse
 {mysidlc}adm         5482 ...       \_ hdbnameserver
 {mysidlc}adm         5551 ...       \_ hdbpreprocessor
 {mysidlc}adm         5554 ...       \_ hdbcompileserver

--- a/adoc/make.sh
+++ b/adoc/make.sh
@@ -5,7 +5,7 @@
 #
 # libreoffice --convert-to svg *odg
 #
-# ALL other libreoffice windows must eb closed for the scripted SVG creation
+# ALL other libreoffice windows must be closed for the scripted SVG creation
 #
 
 #doclist="Asciidoc+Atom-GettingStarted SAP_HA740_certification_notes SAP_HA740_SetupGuide"


### PR DESCRIPTION
In this pr I try to fix a problem with the build document. In some of the examples some variables have not
been replaced correctly. One problem was the {SID} in the /etc/fstab example. The second problem is the variable {sidlc} in the example for output of HDB info.
Let's check, if the build is not ok - did not had the chance to build right now.