### PR TITLE
Update documentation about YaST Firstboot

### DIFF
--- a/xml/deployment_firstboot.xml
+++ b/xml/deployment_firstboot.xml
@@ -115,7 +115,7 @@
 
   <para>
    Customizing the firstboot installation workflow may involve several
-   different components. Customizing them is optional. If you do not make
+   different components. Customizing them is recommended. If you do not make
    any changes, firstboot performs the installation using the default
    settings. The following options are available:
   </para>
@@ -429,8 +429,8 @@
     </listitem>
    </itemizedlist>
    <para>
-    This standard layout of a firstboot installation workflow is not
-    mandatory. You can enable or disable certain components or integrate
+    This standard layout of a firstboot installation workflow is just
+    a template. You may enable or disable certain components or integrate
     your own modules into the workflow. To modify the firstboot workflow,
     manually edit the firstboot configuration file
     <filename>/etc/YaST2/firstboot.xml</filename>. This XML file is a subset
@@ -611,8 +611,7 @@
     <callout arearefs="co.fb.name">
      <para>
       The module name. The module itself must be located under
-      <filename>/usr/share/YaST2/clients</filename> and have the
-      <filename>.ycp</filename> file suffix.
+      <filename>/usr/share/YaST2/clients</filename>.
      </para>
     </callout>
    </calloutlist>
@@ -711,7 +710,7 @@
     <step>
      <para>
       Create your own &yast; module and store the module file
-      <filename><replaceable>module_name</replaceable>.ycp</filename> in
+      <filename><replaceable>module_name</replaceable>.rb</filename> in
       <filename>/usr/share/YaST2/clients</filename>.
      </para>
     </step>
@@ -760,7 +759,7 @@
       <step>
        <para>
         Enter the file name of your module in the <literal>name</literal>
-        element. Omit the full path and the <filename>.ycp</filename>
+        element. Omit the full path and the <filename>.rb</filename>
         suffix.
        </para>
       </step>


### PR DESCRIPTION
Hi there!

David Díaz from YaST team here :)

As a result of the confusion about the `firstboot.xml` control file generated when openQA started to add tests for the YaST Firstboot module<sup>[1,2]</sup>, we would like to adjust a little bit the available documentation. 

As you can see, the main purpose had been to slightly encouraging the user to configure the `firstboot.xml` control file before using it. In other words, to clarify that it is just a template.

Apart from submitted changes, I also would like to know if comments like 

```xml
<!-- NTP Client firstboot_ntp : false -->
```

are relevant. I mean, if they are kind of special instruction at the time to build the documentation. I'm asking that because a couple of listed modules  are actually disabled. Shall I include a similar comment?

Please, note that this is my first PR here. So, if something if wrong do not hesitate to ping me to fix it :) In such case, any help/clue is welcome :)

Thanks!

---

[1] https://bugzilla.suse.com/show_bug.cgi?id=1131301
[2] https://bugzilla.suse.com/show_bug.cgi?id=1131327