### PR TITLE
Update styleroot to use newly packaged SBP layout

### DIFF
--- a/DC-SAP_S4HA10_SetupGuide-SLE12
+++ b/DC-SAP_S4HA10_SetupGuide-SLE12
@@ -5,13 +5,10 @@ ADOC_TYPE="article"
 ADOC_POST="yes"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-#STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
-#DRAFT=yes
 ROLE="sbp"
 PROFROLE="sbp"
 

--- a/DC-SAP_S4HA10_SetupGuide-SLE15
+++ b/DC-SAP_S4HA10_SetupGuide-SLE15
@@ -5,13 +5,10 @@ ADOC_TYPE="article"
 ADOC_POST="yes"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-#STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
-#DRAFT=yes
 ROLE="sbp"
 PROFROLE="sbp"
 

--- a/DC-SBP-AMD-EPYC-SLES12SP3
+++ b/DC-SBP-AMD-EPYC-SLES12SP3
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-AMD-EPYC-SLES12SP3.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-CloudLS-master
+++ b/DC-SBP-CloudLS-master
@@ -5,13 +5,10 @@ ADOC_TYPE="article"
 ADOC_POST="yes"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-#STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
-#DRAFT=yes
 ROLE="sbp"
 PROFROLE="sbp"
 

--- a/DC-SBP-DRBD
+++ b/DC-SBP-DRBD
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-DRBD.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-HANAonKVM-SLES12SP2
+++ b/DC-SBP-HANAonKVM-SLES12SP2
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-HANAonKVM-SLES12SP2.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-IaaS-SAP-Cloud
+++ b/DC-SBP-IaaS-SAP-Cloud
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-IaaS-SAP-Cloud.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-KMP-Manual
+++ b/DC-SBP-KMP-Manual
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-KMP-Manual.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-KMP-Manual-SLE12SP2
+++ b/DC-SBP-KMP-Manual-SLE12SP2
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-KMP-Manual-SLE12SP2.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-Migrate-z-KVM
+++ b/DC-SBP-Migrate-z-KVM
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-Migrate-z-KVM.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-Multi-PXE-Install
+++ b/DC-SBP-Multi-PXE-Install
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-Multi-PXE-Install.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-OracleWeblogic-SLES12SP3
+++ b/DC-SBP-OracleWeblogic-SLES12SP3
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-OracleWeblogic-SLES12SP3.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-Quilting-OSC
+++ b/DC-SBP-Quilting-OSC
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-Quilting-OSC.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-RPM-Packaging
+++ b/DC-SBP-RPM-Packaging
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-RPM-Packaging.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-SAP-AzureSolutionTemplates
+++ b/DC-SBP-SAP-AzureSolutionTemplates
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-SAP-AzureSolutionTemplates.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-SLE-OffLine-Upgrade-Local-Boot
+++ b/DC-SBP-SLE-OffLine-Upgrade-Local-Boot
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-SLE-OffLine-Upgrade-Local-Boot.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-SLE15-Custom-Installation-Medium
+++ b/DC-SBP-SLE15-Custom-Installation-Medium
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-SLE15-Custom-Installation-Medium.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-SLES-MFAD
+++ b/DC-SBP-SLES-MFAD
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-SLES-MFAD.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-SLES12SP1-SAP-migrationguide
+++ b/DC-SBP-SLES12SP1-SAP-migrationguide
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-SLES12SP1-SAP-migrationguide.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-SUMA-on-IBM-PowerVM
+++ b/DC-SBP-SUMA-on-IBM-PowerVM
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-SUMA-on-IBM-PowerVM.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-Spectre-Meltdown-L1TF
+++ b/DC-SBP-Spectre-Meltdown-L1TF
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-Spectre-Meltdown-L1TF.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-intelsupport
+++ b/DC-SBP-intelsupport
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-intelsupport.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-openFaaS
+++ b/DC-SBP-openFaaS
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-openFaas.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-oraclerac
+++ b/DC-SBP-oraclerac
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-oraclerac.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-oracleweblogic
+++ b/DC-SBP-oracleweblogic
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-oracleweblogic.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-performance-tuning
+++ b/DC-SBP-performance-tuning
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-performance-tuning.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-publiccloudinfra
+++ b/DC-SBP-publiccloudinfra
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-publiccloudinfra.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-scominstallguide
+++ b/DC-SBP-scominstallguide
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-scominstallguide.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-scomusermanual
+++ b/DC-SBP-scomusermanual
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-scomusermanual.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-securitymodule
+++ b/DC-SBP-securitymodule
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-securitymodule.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-strategy
+++ b/DC-SBP-strategy
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-strategy.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-strategy-short
+++ b/DC-SBP-strategy-short
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-strategy-short.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-sumaforrhel
+++ b/DC-SBP-sumaforrhel
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-sumaforrhel.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SBP-susemanager
+++ b/DC-SBP-susemanager
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-susemanager.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SLES-JeOS-12SP4-Quickstart
+++ b/DC-SLES-JeOS-12SP4-Quickstart
@@ -5,13 +5,10 @@ ADOC_TYPE="article"
 ADOC_POST="yes"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-#STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
-#DRAFT=yes
 ROLE="sbp"
 PROFROLE="sbp"
 

--- a/DC-SLES-rpiquick
+++ b/DC-SLES-rpiquick
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-rpiquick.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SLES12SP3-rpiquick
+++ b/DC-SLES12SP3-rpiquick
@@ -3,8 +3,6 @@
 ## See /etc/daps/config for documentation of the settings below
 
 MAIN="MAIN-SBP-rpiquick-SLES12SP3.xml"
-ROOTID=""
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns/"
-#FALLBACK_STYLEROOT=""
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"

--- a/DC-SLES4SAP-hana-scaleOut-PerfOpt-12
+++ b/DC-SLES4SAP-hana-scaleOut-PerfOpt-12
@@ -5,13 +5,10 @@ ADOC_TYPE="article"
 ADOC_POST="yes"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-#STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
-#DRAFT=yes
 ROLE="sbp"
 PROFROLE="sbp"
 

--- a/DC-SLES4SAP-hana-sr-guide-PerfOpt-12-Alicloud
+++ b/DC-SLES4SAP-hana-sr-guide-PerfOpt-12-Alicloud
@@ -5,13 +5,10 @@ ADOC_TYPE="article"
 ADOC_POST="yes"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
-
-#STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
-#DRAFT=yes
 ROLE="sbp"
 PROFROLE="sbp"
 

--- a/adoc/SAP_S4HA10_SetupGuide_SLE15.adoc
+++ b/adoc/SAP_S4HA10_SetupGuide_SLE15.adoc
@@ -1404,9 +1404,9 @@ In addition to the already performed tests, you should do the following:
 
 
 
+[[multicluster]]
 == Multi-Node Cluster Setups for an {sapS4}
 
-[[multicluster]]
 *Multinode cluster* setups mean cluster configurations with more than two nodes.
 Depending from the starting point it is possible to extend a two node cluster setup or directly start with
 more than two nodes for an ASCS / ERS high availability setup.


### PR DESCRIPTION
The current workaround for getting the SBP layout was that Meike had to
use specially checked out branch of the suse-xsl repo. Minor tradeof was
that only she could build SBPs properly.

We now have a package for these stylesheets, so the situation gets ate
least marginally better.

@chabowski Let's discuss this one on Wed (or whenever you are back in da office).