### PR TITLE
fixing cluster parameter on-fail=restart, moving them in the correct …

### DIFF
--- a/adoc/SAP-Multi-SID.adoc
+++ b/adoc/SAP-Multi-SID.adoc
@@ -436,15 +436,13 @@ primitive rsc_ip_{sid2}_ERS{inst-ers2} IPaddr2 \
 	op monitor interval=10s timeout=20s
 primitive rsc_sap_{sid2}_ASCS{inst-ascs2} SAPInstance \
 	operations $id=rsc_sap_{sid2}_ASCS{inst-ascs2}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid2}_ASCS{inst-ascs2}_{v-ascs2host} START_PROFILE="/sapmnt/{sid2}/profile/{sid2}_ASCS{inst-ascs2}_{v-ascs2host}" AUTOMATIC_RECOVER=false \
 	meta resource-stickiness=5000 failure-timeout=60 \
         migration-threshold=1 priority=10
 primitive rsc_sap_{sid2}_ERS{inst-ers2} SAPInstance \
 	operations $id=rsc_sap_{sid2}_ERS{inst-ers2}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid2}_ERS{inst-ers2}_{v-ers2host} START_PROFILE="/sapmnt/{sid2}/profile/{sid2}_ERS{inst-ers2}_{v-ers2host}" AUTOMATIC_RECOVER=false IS_ERS=true \
 	meta priority=1000
 group grp_{sid2}_ASCS{inst-ascs2} rsc_ip_{sid2}_ASCS{inst-ascs2} rsc_fs_{sid2}_ASCS{inst-ascs2} rsc_sap_{sid2}_ASCS{inst-ascs2} \
@@ -486,15 +484,13 @@ primitive rsc_ip_{sid3}_ERS{inst-ers3} IPaddr2 \
 	op monitor interval=10s timeout=20s
 primitive rsc_sap_{sid3}_ASCS{inst-ascs3} SAPInstance \
 	operations $id=rsc_sap_{sid3}_ASCS{inst-ascs3}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid3}_ASCS{inst-ascs3}_{v-ascs3host} START_PROFILE="/sapmnt/{sid3}/profile/{sid3}_ASCS{inst-ascs3}_{v-ascs3host}" AUTOMATIC_RECOVER=false \
 	meta resource-stickiness=5000 failure-timeout=60 \
         migration-threshold=1 priority=10
 primitive rsc_sap_{sid3}_ERS{inst-ers3} SAPInstance \
 	operations $id=rsc_sap_{sid3}_ERS{inst-ers3}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid3}_ERS{inst-ers3}_{v-ers3host} START_PROFILE="/sapmnt/{sid3}/profile/{sid3}_ERS{inst-ers3}_{v-ers3host}" AUTOMATIC_RECOVER=false IS_ERS=true \
 	meta priority=1000
 group grp_{sid3}_ASCS{inst-ascs3} rsc_ip_{sid3}_ASCS{inst-ascs3} rsc_fs_{sid3}_ASCS{inst-ascs3} rsc_sap_{sid3}_ASCS{inst-ascs3} \
@@ -780,14 +776,12 @@ primitive rsc_ip_{sid2}_ERS{inst-ers2} IPaddr2 \
 	op monitor interval=10s timeout=20s
 primitive rsc_sap_{sid2}_ASCS{inst-ascs2} SAPInstance \
 	operations $id=rsc_sap_{sid2}_ASCS{inst-ascs2}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid2}_ASCS{inst-ascs2}_{v-ascs2host} START_PROFILE="/sapmnt/{sid2}/profile/{sid2}_ASCS{inst-ascs2}_{v-ascs2host}" AUTOMATIC_RECOVER=false \
 	meta resource-stickiness=5000
 primitive rsc_sap_{sid2}_ERS{inst-ers2} SAPInstance \
 	operations $id=rsc_sap_{sid2}_ERS{inst-ers2}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid2}_ERS{inst-ers2}_{v-ers2host} START_PROFILE="/sapmnt/{sid2}/profile/{sid2}_ERS{inst-ers2}_{v-ers2host}" AUTOMATIC_RECOVER=false IS_ERS=true
 group grp_{sid2}_ASCS{inst-ascs2} rsc_ip_{sid2}_ASCS{inst-ascs2} rsc_fs_{sid2}_ASCS{inst-ascs2} rsc_sap_{sid2}_ASCS{inst-ascs2} \
 	meta resource-stickiness=3000
@@ -824,14 +818,12 @@ primitive rsc_ip_{sid3}_ERS{inst-ers3} IPaddr2 \
 	op monitor interval=10s timeout=20s
 primitive rsc_sap_{sid3}_ASCS{inst-ascs3} SAPInstance \
 	operations $id=rsc_sap_{sid3}_ASCS{inst-ascs3}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid3}_ASCS{inst-ascs3}_{v-ascs3host} START_PROFILE="/sapmnt/{sid3}/profile/{sid3}_ASCS{inst-ascs3}_{v-ascs3host}" AUTOMATIC_RECOVER=false \
 	meta resource-stickiness=5000
 primitive rsc_sap_{sid3}_ERS{inst-ers3} SAPInstance \
 	operations $id=rsc_sap_{sid3}_ERS{inst-ers3}-operations \
-	op monitor interval=11 timeout=60 \
-	op_params on-fail=restart \
+	op monitor interval=11 timeout=60 on-fail=restart \
 	params InstanceName={sid3}_ERS{inst-ers3}_{v-ers3host} START_PROFILE="/sapmnt/{sid3}/profile/{sid3}_ERS{inst-ers3}_{v-ers3host}" AUTOMATIC_RECOVER=false IS_ERS=true
 group grp_{sid3}_ASCS{inst-ascs3} rsc_ip_{sid3}_ASCS{inst-ascs3} rsc_fs_{sid3}_ASCS{inst-ascs3} rsc_sap_{sid3}_ASCS{inst-ascs3} \
 	meta resource-stickiness=3000

--- a/adoc/SAP_S4HA10_SetupGuide_SLE12.adoc
+++ b/adoc/SAP_S4HA10_SetupGuide_SLE12.adoc
@@ -2017,16 +2017,14 @@ primitive rsc_ip_{mySid}_{myInstErs} IPaddr2 \
     op monitor interval=10s timeout=20s
 primitive rsc_sap_{mySid}_{myInstAscs} SAPInstance \
     operations $id=rsc_sap_{mySid}_{myInstAscs}-operations \
-    op monitor interval=11 timeout=60 \
-    op_params on-fail=restart \
+    op monitor interval=11 timeout=60 on-fail=restart \
     params InstanceName={mySid}_{myInstAscs}_{myVipNAscs} \
     START_PROFILE="/sapmnt/{mySid}/profile/{mySid}_{myInstAscs}_{myVipNAscs}" \
     AUTOMATIC_RECOVER=false \
     meta resource-stickiness=5000
 primitive rsc_sap_{mySid}_{myInstErs} SAPInstance \
     operations $id=rsc_sap_{mySid}_{myInstErs}-operations \
-    op monitor interval=11 timeout=60 \
-    op_params on-fail=restart \
+    op monitor interval=11 timeout=60 on-fail=restart \
     params InstanceName={mySid}_{myInstErs}_{myVipNErs} \
     START_PROFILE="/sapmnt/{mySid}/profile/{mySid}_{myInstErs}_{myVipNErs}" \
     AUTOMATIC_RECOVER=false IS_ERS=true

--- a/adoc/SAP_S4HA10_SetupGuide_SLE15.adoc
+++ b/adoc/SAP_S4HA10_SetupGuide_SLE15.adoc
@@ -2010,16 +2010,14 @@ primitive rsc_ip_{mySid}_{myInstErs} IPaddr2 \
     op monitor interval=10s timeout=20s
 primitive rsc_sap_{mySid}_{myInstAscs} SAPInstance \
     operations $id=rsc_sap_{mySid}_{myInstAscs}-operations \
-    op monitor interval=11 timeout=60 \
-    op_params on-fail=restart \
+    op monitor interval=11 timeout=60 on-fail=restart \
     params InstanceName={mySid}_{myInstAscs}_{myVipNAscs} \
     START_PROFILE="/sapmnt/{mySid}/profile/{mySid}_{myInstAscs}_{myVipNAscs}" \
     AUTOMATIC_RECOVER=false \
     meta resource-stickiness=5000
 primitive rsc_sap_{mySid}_{myInstErs} SAPInstance \
     operations $id=rsc_sap_{mySid}_{myInstErs}-operations \
-    op monitor interval=11 timeout=60 \
-    op_params on-fail=restart \
+    op monitor interval=11 timeout=60 on-fail=restart \
     params InstanceName={mySid}_{myInstErs}_{myVipNErs} \
     START_PROFILE="/sapmnt/{mySid}/profile/{mySid}_{myInstErs}_{myVipNErs}" \
     AUTOMATIC_RECOVER=false IS_ERS=true


### PR DESCRIPTION
Good morning Meike,

this is now the path for three documents.

This change was needed:
old ->
op monitor interval=11 timeout=60 \
op_params on-fail=restart \

new->	
op monitor interval=11 timeout=60 on-fail=restart \

Bernd