### PR TITLE
Hiding the Corosync configuration file for now until it is fixed by t…

### DIFF
--- a/adoc/sap_hana_azure-appendix.adoc
+++ b/adoc/sap_hana_azure-appendix.adoc
@@ -497,6 +497,7 @@ op_defaults op-options: \
         record-pending=true
 ----
 
+//// Hiding the Corosync configuration file for now until it is fixed by the SHAP team in the SUSE Github repo
 === _Corosync_ Configurations
 [subs="quotes"]
 ----
@@ -560,6 +561,7 @@ quorum {
 	two_node: 1
 }
 ----
+////
 
 === SAP System Overview
 [subs="quotes"]

--- a/adoc/sap_hana_azure-appendix.adoc
+++ b/adoc/sap_hana_azure-appendix.adoc
@@ -496,8 +496,10 @@ op_defaults op-options: \
         timeout=600 \
         record-pending=true
 ----
+ 
+////
+COMMENT: Hiding the Corosync configuration file for now until it is fixed by the SHAP team in the SUSE Github repo
 
-//// Hiding the Corosync configuration file for now until it is fixed by the SHAP team in the SUSE Github repo
 === _Corosync_ Configurations
 [subs="quotes"]
 ----


### PR DESCRIPTION
Hi, 

I would like to hide the Corosync configuration file for now until it is fixed by the SHAP team in the SUSE Github repo.

Best regards,
Ab