### PR TITLE
SPR - default to database backend for jobservice

### DIFF
--- a/adoc/Private-Registry-Administration.adoc
+++ b/adoc/Private-Registry-Administration.adoc
@@ -144,9 +144,7 @@ Disregarding this recommandation may lead to situation in which the configuratio
 
 [WARNING]
 ====
-A {kube} `StorageClass` with `ReadWriteMany` access mode is required to enable high-availability for some {spr} components:
-* The `jobservice` component
-* The registry component, when a {kube} persistent volume is used as the storage back-end for OCI artifacts
+A {kube} `StorageClass` with `ReadWriteMany` access mode is required to enable high-availability for the {spr} `registry` component, if a {kube} persistent volume is used as the storage back-end for OCI artifacts.
 If a `StorageClass` with `ReadWriteMany` access is not configured for these components, setting the replica count to a value higher than 1 for them will result in failure.
 ====
 
@@ -178,6 +176,13 @@ notary:
 [source,bash]
 ----
 helm -n registry upgrade suse-registry ./harbor -f harbor-values.yaml
+----
+
+Alternatively, `kubectl` may be used directly to scale {spr} components individually, but special care should be taken to keep the `harbor-values.yaml` file updated to reflect the running configuration, otherwise subsequent configuration changes or upgrade operations that require running `helm upgrade` will revert the number of replicas back to the known configuration. For example, to scale the `portal` component to a new value of 3 pods, the following command may be used:
+
+[source,bash]
+----
+kubectl -n registry scale deployment -l component=portal --replicas=3
 ----
 
 ==== Expanding Persistent Volumes Claims

--- a/adoc/Private-Registry-Installation.adoc
+++ b/adoc/Private-Registry-Installation.adoc
@@ -693,7 +693,6 @@ redis:
     password: access-key // <1>
 ----
 <1> Replace `access-key` with the access key retrieved after creating the Azure Cache for Redis instance.
-// TODO AI (Dirk Mueller) needs to be reviewed
 .. Connect to an Amazon ElastiCache Redis service
 +
 Add the following section to the `harbor-values.yaml` file and fill it with information reflecting the Amazon ElastiCache Redis instance previously prepared:
@@ -708,9 +707,6 @@ redis:
     password: "" // <1>
 ----
 <1> Add password if configured manually (not the default) in AWS ElastiCache.
-
-// .. Connect to an Amazon ElastiCache Redis service
-// TODO - AI jsuchome - Add AWS method for Redis
 
 . [[install-resource-limits]] (Optional) Setup Resource Requests and Limits
 +

--- a/adoc/Private-Registry-Installation.adoc
+++ b/adoc/Private-Registry-Installation.adoc
@@ -9,7 +9,7 @@
 *** A predefined external IP address that can be associated with the Load Balancer service used to expose the {spr} services
 *** An FQDN value that can be later on mapped in the external DNS to the external IP address dynamically allocated to the Load Balancer service during installation
 * Choose between using auto-generated TLS certificates or providing your own custom TLS certificates for the Harbor UI/API and Notary API. In the latter case, have the required custom TLS certificates ready.
-* Choose the persistent storage back-end that will be used to store OCI artifacts: a {kube} `StorageClass` or one of the external storage services available from public cloud providers
+* Choose the persistent storage back-end that will be used to store OCI artifacts: a {kube} `StorageClass` or one of the external storage services available from public cloud providers.
 * Verify that the target {kube} cluster provides the required `StorageClass`(es). A `StorageClass` with `ReadWriteMany` access mode is required to fully enable high-availability and scalability for the `registry` {spr} component, unless an external storage service is used to store OCI artifacts.
 * Choose between using an external or internal database service. The internal database service doesn't support high-availability and scalability and is therefore *not recommended for production*.
 The external database service needs to be prepared separately beforehand.
@@ -364,15 +364,12 @@ persistence:
       size:
     database:
       storageClass: ""
-      accessMode: ReadWriteOnce
       size:
     redis:
       storageClass: ""
-      accessMode: ReadWriteOnce
       size:
     trivy:
       storageClass: ""
-      accessMode: ReadWriteOnce
       size:
 ----
 

--- a/adoc/Private-Registry-Installation.adoc
+++ b/adoc/Private-Registry-Installation.adoc
@@ -9,8 +9,8 @@
 *** A predefined external IP address that can be associated with the Load Balancer service used to expose the {spr} services
 *** An FQDN value that can be later on mapped in the external DNS to the external IP address dynamically allocated to the Load Balancer service during installation
 * Choose between using auto-generated TLS certificates or providing your own custom TLS certificates for the Harbor UI/API and Notary API. In the latter case, have the required custom TLS certificates ready.
-* Verify that the target {kube} cluster provides the required `StorageClass`(es). A `StorageClass` with `ReadWriteMany` access mode is required to fully enable high-availability and scalability for {spr} component
-* Choose the persistent storage back-end that will be used to store OCI artifacts.
+* Choose the persistent storage back-end that will be used to store OCI artifacts: a {kube} `StorageClass` or one of the external storage services available from public cloud providers
+* Verify that the target {kube} cluster provides the required `StorageClass`(es). A `StorageClass` with `ReadWriteMany` access mode is required to fully enable high-availability and scalability for the `registry` {spr} component, unless an external storage service is used to store OCI artifacts.
 * Choose between using an external or internal database service. The internal database service doesn't support high-availability and scalability and is therefore *not recommended for production*.
 The external database service needs to be prepared separately beforehand.
 * Choose between using an external or internal Redis service. Similar to the database case, the internal Redis service doesn't support high-availability and scalability and *is not recommended for production*.
@@ -332,13 +332,12 @@ For each component that uses persistent storage, the following settings can be c
 ... `accessMode`: Volumes can be mounted on a container in any way supported by the storage provider. Valid values are:
 [arabic]
 .... `ReadWriteOnce`: the volume can be mounted as read-write by a single container
-.... `ReadWriteMany`: the volume can be mounted as read-write by many containers (required for jobservice when configured in high-availability mode and for registry when configured in high-availability mode and using persistent volume to store OCI artifacts)
+.... `ReadWriteMany`: the volume can be mounted as read-write by many containers. This is only required for the `registry` component, when configured in high-availability mode and using a persistent volume to store OCI artifacts. If an external storage service is used to store OCI artifacts, or if a `ReadWriteMany` `StorageClass` isn't available in your {kube} cluster, this value shouldn't be used.
 (default: `ReadWriteOnce`)
 ... size: the size of the volume to be provisioned (e.g. 5Gi for 5 gigabytes). Default values varies by component:
 +
 [arabic]
 .... registry: 5Gi
-.... jobservice: 1Gi
 .... databasae: 1Gi
 .... redis: 1Gi
 .... trivy: 5Gi
@@ -352,7 +351,7 @@ It is recommended to carefully plan and set the volumes size according to the ex
 Expanding in-use persistent volumes claims is supported only by some storage providers and in some cases it requires restarting the pods which will impact the service availability.
 ====
 
-For configuring persistent storage update `harbor-values.yaml` configuration file with the following configuration and set their values accordingly:
+For configuring persistent storage, update the `harbor-values.yaml` configuration file with the following configuration and set their values accordingly:
 
 .harbor-values.yaml
 [source,yaml]
@@ -361,40 +360,35 @@ persistence:
   persistentVolumeClaim:
     registry:
       storageClass: ""
-      accessMode:
-      size:
-    jobservice:
-      storageClass: ""
-      accessMode:
+      accessMode: ReadWriteMany
       size:
     database:
       storageClass: ""
-      accessMode:
+      accessMode: ReadWriteOnce
       size:
     redis:
       storageClass: ""
-      accessMode:
+      accessMode: ReadWriteOnce
       size:
     trivy:
       storageClass: ""
-      accessMode:
+      accessMode: ReadWriteOnce
       size:
 ----
 
 .Using external services
 [NOTE]
 ====
-The above settings will be ignored and may be omitted for components configured to use an external service (`database`, `redis`), as well as for the registry component when external storage is configured for OCI artifacts.
+The above settings will be ignored and may be omitted for components configured to use an external service (`database`, `redis`), as well as for the `registry` component when external storage is configured for OCI artifacts.
 ====
 
 [WARNING]
 ====
-In the absence of a {kube} StorageClass with ReadWriteMany access mode capabilities, the `updateStrategy.type` option must set to `Recreate` in the `harbor-values.yaml` file, otherwise running `helm upgrade` to apply subsequent configuration changes or to perform upgrades will result in failure:
+If a {kube} persistent volume is configured to store OCI artifacts instead of an external storage service, and if your {kube} cluster does not provide a `StorageClass` with `ReadWriteMany` access mode capabilities, the `updateStrategy.type` option must set to `Recreate` in the `harbor-values.yaml` file, otherwise running `helm upgrade` to apply subsequent configuration changes or to perform upgrades will result in failure:
 
 [source,yaml]
 ----
-# The update strategy for deployments with persistent volumes(jobservice, registry
-# and chartmuseum): "RollingUpdate" or "Recreate"
+# The update strategy for deployments with persistent volumes (registry): "RollingUpdate" or "Recreate"
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
   type: Recreate
@@ -477,20 +471,16 @@ notary:
 +
 [WARNING]
 ====
-A {kube} `StorageClass` with `ReadWriteMany` access mode is required to enable high-availability for some {spr} components:
+A {kube} `StorageClass` with `ReadWriteMany` access mode is required to enable high-availability for the {spr} `registry` component, when a {kube} persistent volume is used as the storage back-end for OCI artifacts.
 
-* The `jobservice` component
-* The registry component, when a {kube} persistent volume is used as the storage back-end for OCI artifacts
-
-If a `StorageClass` with `ReadWriteMany` access is not available for your {kube} cluster, setting the replica count to a value higher than 1 for these components will result in installation failure.
+If a `StorageClass` with `ReadWriteMany` access is not available for your {kube} cluster, setting the replica count to a value higher than 1 for the `registry` component will result in installation failure.
 Furthermore, using `helm upgrade` to apply subsequent configuration changes or to perform upgrades will also result in failures without a `ReadWriteMany` access mode `StorageClass`.
 To prevent that, ensure the `updateStrategy.type` option is set to `Recreate` in the `harbor-values.yaml` file:
 
 .harbor-values.yaml
 [source,yaml]
 ----
-# The update strategy for deployments with persistent volumes(jobservice, registry
-# and chartmuseum): "RollingUpdate" or "Recreate"
+# The update strategy for deployments with persistent volumes(registry): "RollingUpdate" or "Recreate"
 # Set it as "Recreate" when "RWM" for volumes isn't supported
 updateStrategy:
   type: Recreate

--- a/adoc/Private-Registry-Requirements.adoc
+++ b/adoc/Private-Registry-Requirements.adoc
@@ -28,8 +28,8 @@ The following types of storage are required for {sprpbh}:
 ** {spr} internal stateful components require persistent volumes to store their data in a way that survives pod restarts.
 A default {kube} `StorageClass` is needed to dynamically provision the volumes. Alternatively, explicit `StorageClass` values may be configured for each component.
 * {kube} persistent shared volumes
-** In addition to regular persistent volumes, a {kube} `StorageClass` that supports `ReadWriteMany` access mode is required to deploy the jobservice and registry components a highly-available and scalable setup. Alternatively, HA and scalability may be disabled for these components
-* Storage backend for OCI artifacts
+** In addition to regular persistent volumes, a {kube} `StorageClass` that supports `ReadWriteMany` access mode is required to deploy the `registry` component - the component providing the OCI registry API and responsible for storing OCI artifacts - in a highly-available and scalable setup. If such a `StorageClass` isn't available in your {kube} cluster, an external storage backend may be used instead (see next point). Ultimately, a regular `ReadWriteOnce` {kube} `StorageClass` may still be used for the `registry` component, but with HA and scalability features selectively disabled.
+* External storage for OCI artifacts
 ** {spr} may optionally be configured to store OCI artifacts (e.g. container images and charts) in an external storage backend such as Azure Blob Storage or Amazon S3, instead of the {kube} provided persistent volumes.
 
 [NOTE]
@@ -41,8 +41,8 @@ Refer to link:https://documentation.suse.com/suse-caasp/4.5/html/caasp-admin/_st
 For public cloud deployments it is recommended to use the available hosted solutions:
 
 * Azure Blob Storage or Amazon S3 for storing OCI artifacts
-* The Azure File Share or Amazon EFS {kube} `StorageClass` for components that require `ReadWriteMany` access mode
-* The Azure Managed Disk or Amazon EBS {kube} `StorageClass` for all other components that require persistent storage
+* The Azure File Share or Amazon EFS {kube} `StorageClass` for the `registry` component, unless external storage is used to store OCI artifacts
+* The Azure Managed Disk or Amazon EBS {kube} `StorageClass` for other components that require persistent storage
 
 Refer to the table in <<supported-deployment>> for more details.
 
@@ -272,9 +272,9 @@ The replica count can be configured in the Helm chart individually for every com
 * HA Ingress Controller
 +
 If a {kube} Ingress controller is used to expose the {spr} services, use a replica count value of 2 or higher for the ingress controller deployment.
-* Use a `ReadWriteMany` access mode {kube} `StorageClass`
+* Use external storage, or a `ReadWriteMany` access mode {kube} `StorageClass` to store OCI artifacts
 +
-For some {spr} internal stateful components (registry, jobservice), increasing the number of replicas is only possible with persistent volumes that support the `ReadWriteMany` access mode. High availability may be explicitly disabled only for these components, if such a `StorageClass` cannot be provided.
+If the {spr} `registry` internal component is configured to use {kube} persistent volumes to store OCI artifacts instead of an external storage service such as Azure Blob Storage or Amazon S3, increasing the number of replicas is only possible if the {kube} `StorageClass` supports the `ReadWriteMany` access mode. High availability may be explicitly disabled only for this component, if such a `StorageClass` cannot be provided.
 * *The internal database and redis component do not support high availability.*
 * Database can only be HA when {spr} is connected to an external HA database setup
 +


### PR DESCRIPTION
The jobservice SPR component is now using the database to
store its persistent state artifacts, instead of a Kubernetes
persistent shared volume.
Removes all mentions of jobservice as a component requiring
persistent storage, which simplifies installation and administration
procedures.