### PR TITLE
At request of @jsuchomel amend start cmd & remove chmod cmd

### DIFF
--- a/adoc/Private-Registry-Airgap.adoc
+++ b/adoc/Private-Registry-Airgap.adoc
@@ -102,8 +102,10 @@ sudo cp images/*.tar /var/lib/rancher/k3s/agent/images/
 [source,bash]
 ----
 su
-k3s server
+k3s server --write-kubeconfig-mode 644
 ----
+TIP: The additional option tells `k3s` to reset the permissions on
+`/etc/rancher/k3s/k3s.yaml` as it loads.
 +
 To see more information, you can to pass the `--debug` option to the command,
 but you will receive a *lot* of information. Alternatively, you can start the
@@ -137,8 +139,6 @@ your own `kubectl` file, point to the appropriate config file first:
 [source,bash]
 ----
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-# installed kubeconfig is only readable by root after the installation
-sudo chmod a+r /etc/rancher/k3s/k3s.yaml
 kubectl get deployments
 ----
 
@@ -208,8 +208,8 @@ Save these files as `pv-trivy.yaml` and `pvc-trivy.yaml`.
 
 .. Create the directory `/data/trivy-pv` (see the value of `path` in the
 `pv-trivy.yaml` file). Unpack the downloaded Trivy database under the `trivy/db`
-subdirectory, and change the ownership of the whole directory to user
-and group 10000:
+subdirectory, and change the ownership of the whole directory to user and group
+10000:
 +
 [source,bash]
 ----


### PR DESCRIPTION
As per @jsuchome's comment in Rocket.chat #doc-ses:

> ok ... anyway, my point was, I wrote into the docs to chmod `/etc/rancher/k3s/k3s.yaml` after
> `k3s server start`, but it actually can be started right with the correct mode, with `k3s server --write-kubeconfig-mode 644
 