### PR TITLE
Remove queue_depth recommendation

### DIFF
--- a/adoc/VMware67-SES5.adoc
+++ b/adoc/VMware67-SES5.adoc
@@ -159,7 +159,6 @@ image::{imgpath}iqn_advanced.png[Set IQN Advanced Properties, scaledwidth=80%]
 image::{imgpath}VMFS_lun_create_basic.png[Create VMFS LUN - Basic Dialog, scaledwidth=80%]
 ** Click the gear next to the image name.  This opens the advanced options dialogue. In this screen, set the following values:
 *** lun:{Desired LUN ID number}
-*** queue_depth:512
 *** emulate_pr:0
 *** emulate_tpu:1
 *** emulate_tpws:1


### PR DESCRIPTION
It is not possible to set this for iSCSI and will result in an error if it is attempted to do so.