### PR TITLE
Last proof reading of the GCC 10 paper

### DIFF
--- a/xml/MAIN-SBP-GCC-10.xml
+++ b/xml/MAIN-SBP-GCC-10.xml
@@ -179,7 +179,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
      conversions</emphasis>
     <footnote>
      <para> Proposal P0067R5</para>
-    </footnote> have extra limitations. Most of the <literal>C++20</literal> features are
+    </footnote> have extra limitations. Most of <literal>C++20</literal> features are
     implemented in GCC 10 as experimental features. Try them out with appropriate caution. Most
     notably, <emphasis role="italic">Modules</emphasis>
     <footnote>
@@ -516,7 +516,7 @@ S | Name                         | Summary
   <para> Some projects use <literal>-fno-strict-aliasing</literal> to work around type punning
    problems in the source code. This is not recommended except for very low-level hand optimized
    code such as the Linux kernel. Type-based alias analysis is a very powerful tool. It is used to
-   enable other transforms, such as store, to load propagation that in turn enables other
+   enable other transforms, such as store-to-load propagation that in turn enables other
    transformations, such as aggressive inlining, vectorization and other high level transformations. </para>
 
   <para> With the <literal>-g</literal> switch GCC still tries hard to generate useful debug
@@ -531,7 +531,7 @@ S | Name                         | Summary
     site</link>. </para>
 
   <para> Bear in mind that although almost all optimizing compilers have the concept of optimization
-   levels. But even if their optimization levels might have the same names as those in GCC, they do
+   levels and their optimization levels often have the same names as those in GCC, they do
    not necessarily mean to make the same trade-offs. Famously, GCC's <literal>-Os</literal>
    optimizes for size much more aggressively than LLVM/Clang's level with the same name. Therefore,
    it often produces slower code; the more equivalent option in Clang is <literal>-Oz</literal>
@@ -694,7 +694,7 @@ S | Name                         | Summary
     <para> The symbol promotion is controlled by resolution information given to the linker and
      depends on type of the DSO build. When producing a dynamically loaded shared library, all
      symbols with default visibility can be overwritten by the dynamic linker. This blocks the
-     promotion of all functions not declared inline, Thus it is necessary to use the hidden
+     promotion of all functions not declared inline, thus it is necessary to use the hidden
      visibility wherever possible to achieve best results. Similar problems happen even when
      building static libraries with <literal>-rdynamic</literal>. </para>
    </note>
@@ -759,7 +759,7 @@ int foo_v1 (void)
    which parts of a program are the <emphasis role="italic">hot</emphasis> ones is difficult, and
    even sophisticated estimation algorithms implemented in GCC are no good match for a measurement. </para>
 
-  <para> If you want to add an extra level of complexity to the build system of your project, you
+  <para> If you do not mind adding an extra level of complexity to the build system of your project, you
    can make such measurement part of the process. The <emphasis role="strong">makefile</emphasis>
    (or any other) build script needs to compile it twice. The first time it needs to compile with
    the <literal>-fprofile-generate</literal> option and then execute the first binary in one or
@@ -853,7 +853,7 @@ int foo_v1 (void)
 
    <para> In <xref linkend="sec-gcc10-optimization_levels"/> we recommend that HPC workloads are
     compiled with <literal>-O3</literal> and benchmarks with <literal>-Ofast</literal>. But it is
-    still interesting to look at integer crunching benchmarks built with <literal>-O2</literal> only
+    still interesting to look at integer crunching benchmarks built with only <literal>-O2</literal>
     because that is how Linux distributions often build the programs from which they were extracted.
     We have already mentioned that almost the whole openSUSE Tumbleweed distribution is now built
     with LTO, and selected packages with PGO, and the following paragraphs demonstrate why. </para>
@@ -988,7 +988,7 @@ int foo_v1 (void)
      <xref linkend="fig-gcc10-specfp-ofast-pgolto-geomean" xrefstyle="template:Figure %n"/> again
     illustrates the overall effect on the whole suite and <xref
      linkend="fig-gcc10-specfp-ofast-pgolto-perf-indiv" xrefstyle="template:figure %n"/> the
-    benchmarks that benefit the most. All the omitted benchmarks had comparable runtimes regardless
+    benchmarks that benefit the most. All omitted benchmarks had comparable runtimes regardless
     of the mode of compilation, except for <literal>521.wrf_r</literal> where the PGO profiling data
     seem to be damaged in the build process, resulting in 13% slowdown with PGO (see <link
      xlink:href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90364">GCC bug 90364</link>). This
@@ -1033,7 +1033,7 @@ int foo_v1 (void)
     EPYC 7502P Processor, when all benchmarks are compiled with <literal>-Ofast</literal> and
      <literal>-march=native</literal>. Note that the latter option means that both compilers differ
     in their CPU targets because GCC 7.5 does not know the Zen 2 core. This in turn means that in
-    big parts the optimization benefits presented here are because of the fact that the newer
+    large part the optimization benefits presented here are because of the fact that the newer
     compiler can take advantage of the full width of vector paths in the processor. Nevertheless, be
     aware that simply using wider vectors everywhere often backfires. GCC has made substantial
     advancements over the recent years, both in its vectorizer and other optimizers, to avoid such
@@ -1120,8 +1120,8 @@ int foo_v1 (void)
     on the table. This section uses the SPEC FPrate 2017 test suite to illustrate how much
     performance that might be. </para>
    <para> We have built the benchmarking suite with LTO, optimization level <literal>-O3</literal>
-    and <literal>-march=native</literal> to target the native ISA of our AMD EPYC 7502P Processor.
-    And we compared its runtime score against the suite built with these options and
+    and <literal>-march=native</literal> to target the native ISA of our AMD EPYC 7502P Processor
+    and we compared its runtime score against the suite built with these options and
      <literal>-ffast-math</literal>. As you can see in <xref
      linkend="fig-gcc10-specfp-o3-fastmath-geomean" xrefstyle="template:figure %n"/>, the geometric
     means grew by over 8%, but a quick look at <xref linkend="fig-gcc10-specfp-o3-fastmath-indiv"
@@ -1211,7 +1211,7 @@ int foo_v1 (void)
     where ICC achieves 174% compared to itself without LTO. <literal>548.exchange2_r</literal> is
     the only Fortran benchmark in the integer suite and its only hot function contains a recursive
     call in a deep loop nest which poses a problem for many loop optimizers. Furthermore, it can be
-    made faster up by inter-procedural constant propagation and cloning if performed to an extent
+    made faster by inter-procedural constant propagation and cloning if performed to an extent
     that would typically be excessive. When GCC 10 is instructed to do that with the parameters
      <literal>--param ipa-cp-eval-threshold=1 --param ipa-cp-unit-growth=80</literal>, it achieves a
     score on par with ICC with LTO, even without LTO. We do not expect users to compile with such
@@ -1367,7 +1367,7 @@ int foo_v1 (void)
       >https://wiki.mozilla.org/TestEngineering/Performance/Talos/Tests#Responsiveness</link>
     </para>
    </footnote> measuring how responsive Firefox is while carrying out a non-trivial workload. The
-   Talos test we have chosen to focus on is called <emphasis role="italic">perf reftest
+   last Talos test we have chosen to focus on is called <emphasis role="italic">perf reftest
     singletons</emphasis>
    <footnote>
     <para>
@@ -1384,7 +1384,7 @@ int foo_v1 (void)
      <link xlink:href="https://browserbench.org/Speedometer2.0/"
       >https://browserbench.org/Speedometer2.0/</link>
     </para>
-   </footnote> to cross-check selected results from Talos on AMD Ryzen 7 3700X 8-Core Processor.
+   </footnote> to cross-check selected results from Talos on an AMD Ryzen 7 3700X 8-Core Processor.
    Speedometer is a rather simple benchmark which simulates user actions for adding, completing, and
    removing to-do items using DOM APIs in different ways. Speedometer is also part of the profile
    train run. </para>
@@ -1475,7 +1475,7 @@ int foo_v1 (void)
     This section aims to show that GCC 10 produces faster code also when emitting instructions for
     any <literal>x86_64</literal> system and running on processors that are not as new. We have
     compared Firefox binaries built with GCC 7.5 and 10.2 using the least and the most powerful
-    methods described in the previous section, <literal>-O2</literal> with the traditional built,
+    methods described in the previous section, <literal>-O2</literal> with the traditional build,
     and <literal>-O3</literal> with both LTO and PGO. Their respective sizes are very similar but
     the one created with GCC 10 has always performed noticeably better. In the tp5o responsiveness
     benchmark, the simple <literal>-O2</literal> build was 18% faster. Even when using the full


### PR DESCRIPTION
- C++ features should not have definitive article
- hyphenate store-to-load
- "although" needs an opposing clause in the same sentence, so connected
  two sentences.
- fixed capitalization inside a sentence
- clarify that adding extra complexity is a cost, not a goal
- changed position of "only" so that it is clear it describes "-O2" and
  not "because"
- remove definite article in "all omitted benchmarks"
- in big parts -> in large part
- connect two sentences that sound unnatural separated
- remove "up" which was probably left behind when "sped up" was
  changed to "made faster"
- perf reftest is the *last* test the we have focused on, not the one
  we have focused on
- added a missing indefinite article before AMD Ryzen 7 3700X 8-Core
  Processor
- traditional build, not traditional built