### PR TITLE
Fix titles of Brent Hollingsworth and Martin Jambor

### DIFF
--- a/xml/MAIN-SBP-AMD-EPYC-3-SLES15SP2.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-3-SLES15SP2.xml
@@ -44,14 +44,14 @@
     <author>
       <personname>
         <firstname>Martin</firstname>
-        <surname>Jambor, Tool Chain Developer, SUSE</surname>
+        <surname>Jambor, Toolchain Developer, SUSE</surname>
       </personname>
     </author>
 
     <author>
       <personname>
         <firstname>Brent</firstname>
-        <surname>Hollingsworth, Alliance Manager, AMD</surname>
+        <surname>Hollingsworth, Engineering Manager, AMD</surname>
       </personname>
     </author>
 

--- a/xml/MAIN-SBP-GCC-10.xml
+++ b/xml/MAIN-SBP-GCC-10.xml
@@ -60,7 +60,7 @@
   <author>
    <personname>
     <firstname>Brent</firstname>
-    <surname>Hollingsworth, Alliance Manager, AMD</surname>
+    <surname>Hollingsworth, Engineering Manager, AMD</surname>
    </personname>
   </author>
 


### PR DESCRIPTION
- AMD requested to change Brent's title to Engineering Manager in
  papers published this year (and from now on).
- Toolchain in my title also should be one word