### PR TITLE
Update sample corosync configs to prevent corosync parse errors

### DIFF
--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12-AWS.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12-AWS.adoc
@@ -1556,12 +1556,14 @@ logging {
 nodelist {
    node {
      ring0_addr: ip-node-1-a
-     ring1_addr: ip-node-1-b # redundant ring
+     # redundant ring
+     ring1_addr: ip-node-1-b
      nodeid: 1
    }
    node {
      ring0_addr: ip-node-2-a
-     ring1_addr: ip-node-2-b # redundant ring
+     # redundant ring
+     ring1_addr: ip-node-2-b
      nodeid: 2
    }
 }

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15-AWS.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15-AWS.adoc
@@ -1556,12 +1556,14 @@ logging {
 nodelist {
    node {
      ring0_addr: ip-node-1-a
-     ring1_addr: ip-node-1-b # redundant ring
+     # redundant ring
+     ring1_addr: ip-node-1-b
      nodeid: 1
    }
    node {
      ring0_addr: ip-node-2-a
-     ring1_addr: ip-node-2-b # redundant ring
+     # redundant ring
+     ring1_addr: ip-node-2-b
      nodeid: 2
    }
 }


### PR DESCRIPTION
If the user happens to copy the sample config and leave the `# redundant ring comments` after the ring address it causes a corosync parsing error - "[MAIN ] parse error in config: Not all bind address belong to the same IP family". Moved the comments above ring1_addr as empty lines and lines starting with # are ignored by the parser.
