### PR TITLE
Drop macvtap from supported KubeVirt features

### DIFF
--- a/xml/MAIN-SBP-KubeVirt-SLES15SP3.xml
+++ b/xml/MAIN-SBP-KubeVirt-SLES15SP3.xml
@@ -592,9 +592,6 @@ volumes:
     <listitem>
      <para> masquerade </para>
     </listitem>
-    <listitem>
-     <para> macvtap </para>
-    </listitem>
    </itemizedlist>
   </sect2>
 


### PR DESCRIPTION
Small update for the KubeVirt doc: dropping `macvtap` from the list of supported features since at first the focus will be on `bridge` and `masquerade`.

/cc @chabowski , @jfehlig , @hw-claudio 