### PR TITLE
Update SAP NW setup guide to address a few issues

### DIFF
--- a/adoc/SAP_HA740_SetupGuide_AWS.adoc
+++ b/adoc/SAP_HA740_SetupGuide_AWS.adoc
@@ -729,8 +729,8 @@ will run the SAP ASCS and the ERS service.
 
 [subs="specialchars,attributes"]
 ----
-efs-name:SYS     /usr/sap/HA1/SYS    nfs4	rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2	0 0
-efs-name:sapmnt  /sapmnt             nfs4	rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2	0 0
+efs-name:SYS     /usr/sap/HA1/SYS    nfs4	rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport	0 0
+efs-name:sapmnt  /sapmnt             nfs4	rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport	0 0
 ----
 
 Replace _efs-name_ with the appropriate DNS name.
@@ -1148,24 +1148,24 @@ Run the following commands as root on both cluster nodes:
 ----
 OCF_RESKEY_device="efs-name:ASCS00" \
 OCF_RESKEY_directory="/usr/sap/HA1/ASCS00" OCF_RESKEY_fstype=nfs4 \
-OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
 OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/heartbeat/Filesystem start
 
 OCF_RESKEY_device="efs-name:ERS10" \
 OCF_RESKEY_directory="/usr/sap/HA1/ERS10" OCF_RESKEY_fstype=nfs4 \
-OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
 OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/heartbeat/Filesystem start
 
 df -k
 
 OCF_RESKEY_device="efs-name:ASCS00" \
 OCF_RESKEY_directory="/usr/sap/HA1/ASCS00" OCF_RESKEY_fstype=nfs4 \
-OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
 OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/heartbeat/Filesystem stop
 
 OCF_RESKEY_device="efs-name:ERS10" \
 OCF_RESKEY_directory="/usr/sap/HA1/ERS10" OCF_RESKEY_fstype=nfs4 \
-OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+OCF_RESKEY_options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
 OCF_ROOT=/usr/lib/ocf /usr/lib/ocf/resource.d/heartbeat/Filesystem stop
 
 df -k
@@ -1534,10 +1534,10 @@ availability zone.
 
 [subs="attributes"]
 ----
-efs-name:sapcd     /sapcd    nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
-efs-name:sapmnt    /sapmnt   nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
-efs-name:DVEBMGS01 /usr/sap/HA1/DVEBMGS01  nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
-efs-name:SYS       /usr/sap/HA1/SYS        nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
+efs-name:sapcd     /sapcd    nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
+efs-name:sapmnt    /sapmnt   nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
+efs-name:DVEBMGS01 /usr/sap/HA1/DVEBMGS01  nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
+efs-name:SYS       /usr/sap/HA1/SYS        nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
 ----
 
 Replace the variable _efs-name_ with the appropriate DNS name.
@@ -1574,10 +1574,10 @@ availability zone.
 
 [subs="attributes"]
 ----
-efs-name:sapcd     /sapcd            nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
-efs-name:sapmnt    /sapmnt           nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
-efs-name:D02       /usr/sap/HA1/D02  nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
-efs-name:SYS       /usr/sap/HA1/SYS  nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0
+efs-name:sapcd     /sapcd            nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
+efs-name:sapmnt    /sapmnt           nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
+efs-name:D02       /usr/sap/HA1/D02  nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
+efs-name:SYS       /usr/sap/HA1/SYS  nfs4    rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,_netdev,noresvport 0 0
 ----
 
 Replace the variable _efs-name_ with the appropriate DNS name.
@@ -1884,7 +1884,7 @@ Enter the following information to the file _crm-bs.txt_:
 ----
 property cib-bootstrap-options: \
     stonith-enabled="true" \
-    stonith-action="poweroff" \
+    stonith-action="off" \
     stonith-timeout="600s"
 rsc_defaults rsc-options: \
 	resource-stickiness=1 \
@@ -1894,7 +1894,7 @@ op_defaults op-options: \
 	record-pending=true
 ----
 
-The setting _poweroff_ forces the agents to shut down the instance.
+The setting _off_ forces the agents to shut down the instance.
 This is desirable to avoid split brain scenarios on AWS.
 
 Add the configuration to the cluster:
@@ -1913,7 +1913,7 @@ Create a file with the following content:
 primitive res_AWS_STONITH stonith:external/ec2 \
 op start interval=0 timeout=180 \
 op stop interval=0 timeout=180 \
-op monitor interval=120 timeout=60 \
+op monitor interval=300 timeout=60 \
 params tag=pacemaker profile=cluster
 ----
 
@@ -1946,7 +1946,7 @@ ASCS primitive and the ASCS group to it. Do not forget to save your changes.
 primitive rsc_fs_{mySID}_{myInstAscs} Filesystem \
     params  device="{myDevPartAscs}" directory="/usr/sap/{mySID}/{myInstAscs}" \
             fstype="nfs4" \
-            options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+            options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
     op start timeout=60s interval=0 \
     op stop timeout=60s interval=0 \
     op monitor interval=200s timeout=40s
@@ -2067,7 +2067,7 @@ The specific parameter __IS_ERS=true__ should only be set for the ERS instance.
 ----
 primitive rsc_fs_{mySID}_{myInstErs} Filesystem \
   params device="{myDevPartErs}" directory="/usr/sap/{mySID}/{myInstErs}" fstype=nfs4 \
-  options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+  options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
   op start timeout=60s interval=0 \
   op stop timeout=60s interval=0 \
   op monitor interval=200s timeout=40s
@@ -3330,19 +3330,19 @@ node 1084753932: {myNode2}
 primitive res_AWS_STONITH stonith:external/ec2 \
         op start interval=0 timeout=180 \
         op stop interval=0 timeout=180 \
-        op monitor interval=120 timeout=60 \
+        op monitor interval=300 timeout=60 \
         params tag=pacemaker profile=cluster
 primitive rsc_fs_{mySID}_{myInstAscs} Filesystem \
   params device="efs-name:/ASCS00" \
          directory="/usr/sap/HA1/ASCS00" fstype=nfs4 \
-         options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+         options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
 	op start timeout=60s interval=0 \
 	op stop timeout=60s interval=0 \
 	op monitor interval=200s timeout=40s
 primitive rsc_fs_{mySID}_{myInstErs} Filesystem \
   params device="efs-name:/ERS10" \
     directory="/usr/sap/HA1/ERS10" fstype=nfs4 \
-    options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2" \
+    options="rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport" \
 	op start timeout=60s interval=0 \
 	op stop timeout=60s interval=0 \
 	op monitor interval=20s timeout=40s
@@ -3404,7 +3404,7 @@ property cib-bootstrap-options: \
     dc-version=1.1.15-21.1-e174ec8 \
     cluster-infrastructure=corosync \
     stonith-enabled=true \
-    stonith-action=poweroff \
+    stonith-action=off \
     stonith-timeout=600s \
     last-lrm-refresh=1513844735
 rsc_defaults rsc-options: \


### PR DESCRIPTION
1) add nfs mount option 'noresvport' for efs mounts.

https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-nfs-mount-settings.html

2) change stonith-action from 'poweroff' to 'off' to prevent warning about poweroff being deprecated and possibly removed in later version.

https://forums.suse.com/discussion/14182/sbd-fencing-to-shutdown-and-not-restart-the-node-in-cluster
https://clusterlabs.org/pacemaker/doc/deprecated/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-cluster-options.html
https://github.com/ClusterLabs/cluster-glue/blob/1753f5e090d10e173b909cdd9df5e7a60a36559a/lib/plugins/stonith/external/ec2#L392

3) Increase monitoring interval for STONITH device to prevent instance metadata query throttling.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instancedata-throttling
too frequent of monitoring not recommended - https://clusterlabs.org/pacemaker/doc/crm_fencing.html
https://docs.aws.amazon.com/sap/latest/sap-netweaver/cluster-resources-sap-netweaver-ha.html#stonith-cluster-resources-sap-netweaver-ha