### PR TITLE
SAP Best Practices moved to an own site

### DIFF
--- a/adoc/SAP-Multi-SID.adoc
+++ b/adoc/SAP-Multi-SID.adoc
@@ -123,7 +123,7 @@
 :autoYastGuide12: https://documentation.suse.com/sles/12-SP4/html/SLES-all/book-autoyast.html
 :haAdminGuide12: https://documentation.suse.com/sle-ha/12-SP4/html/SLE-HA-all/book-sleha.html
 :launchPadNotes: https://launchpad.support.sap.com/#/notes/
-:reslibrary: https://documentation.suse.com/sbp/all/
+:reslibrary: https://documentation.suse.com/sbp/sap/
 :refsidadm: <sidadm>
 :refHost1: <host1>
 :refInst: <instanceNumber>
@@ -179,7 +179,7 @@ For the latest product documentation updates, see https://documentation.suse.com
 More guides and best practices documents referring to SUSE Linux Enterprise Server and {sap} can be
 found and downloaded at the SUSE Best Practices Web page:
 
-https://documentation.suse.com/sbp/all
+https://documentation.suse.com/sbp/sap
 
 Here you get access to guides for {SAPHANA} system replication
 automation and High Availability (HA) scenarios for {SAPNw} and {s4hana}.
@@ -377,7 +377,7 @@ WARNING: When adding more resources, be aware of the following risks:
 
 ==== Installation
 The installation process is described in the *SUSE Best Practices* guides for {sapS4} and {sapNW}. They can be found here:
-https://documentation.suse.com/sbp/all
+https://documentation.suse.com/sbp/sap
 
 Repeat the steps for preparing the hosts and infrastructure:
 
@@ -399,7 +399,7 @@ The tested setup was done with up to *five* SID in one cluster.
 === Example ENSA1 in a Two-Node Cluster
 //[[2nensa1]]
 As known from the setup based on the *SUSE Best Practices* document for {sapNW}
-(https://documentation.suse.com/sbp/all -> {sapNW} High Availability Cluster 7.40 - Setup Guide),
+(https://documentation.suse.com/sbp/sap -> {sapNW} High Availability Cluster 7.40 - Setup Guide),
 the cluster integration can be done with a configuration file. Create one configuration file for each SID
 and load them one by one into the cluster. The description below will help to do the steps in the right direction.
 
@@ -740,7 +740,7 @@ _As user _{sid2-lc}adm_, for example on ASCS host, check the SAP system
 === Example ENSA2 in a Two-Node Cluster
 //[[2nensa2]]
 As known from the setup based on the *SUSE Best Practice* document for {sapS4}
-(https://documentation.suse.com/sbp/all -> {sapS4} - Enqueue Replication 2 High Availability Cluster - Setup Guide),
+(https://documentation.suse.com/sbp/sap -> {sapS4} - Enqueue Replication 2 High Availability Cluster - Setup Guide),
 the cluster integration can be done with a configuration file. Create one configuration file for each SID
 and load them one by one into the cluster. The following description will help to do the steps in the right direction.
 
@@ -935,7 +935,7 @@ _As user *root*_ showing a cluster configuration for two {sap} systems
 ====
 === Example ENSA1 in a Multi-Node Cluster
 This base setup is already documented in the *SUSE Best Practices* document for {sapNW}
-(https://documentation.suse.com/sbp/all -> {sapS4} - SAP NetWeaver High Availability Cluster 7.40 - Setup Guide - Best Practice Guide).
+(https://documentation.suse.com/sbp/sap -> {sapS4} - SAP NetWeaver High Availability Cluster 7.40 - Setup Guide - Best Practice Guide).
 The OS and node preparation must be done for each future cluster member:
 
 * patch level
@@ -950,7 +950,7 @@ and load them one by one into the cluster. The steps are equal to the steps desc
 
 === Example ENSA2 in a Multi-Node Cluster
 This base setup is already documented in the *SUSE Best Practices* document for {sapS4}
-(https://documentation.suse.com/sbp/all -> {sapS4} - Enqueue Replication 2 High Availability Cluster - Best Practice Guide).
+(https://documentation.suse.com/sbp/sap -> {sapS4} - Enqueue Replication 2 High Availability Cluster - Best Practice Guide).
 The OS and node preparation must be done for each future cluster member:
 
 - patch level
@@ -967,8 +967,8 @@ and load them one by one into the cluster. The steps are equal to the steps desc
 //[[2nensa1ensa2]]
 
 As known from the setup based on the *SUSE Best Practices* document for {sapNW} and {sapS4}
-(https://documentation.suse.com/sbp/all -> {sapNW} High Availability Cluster 7.40 - Setup Guide)
-(https://documentation.suse.com/sbp/all -> {sapS4} - Enqueue Replication 2 High Availability Cluster - Setup Guide),
+(https://documentation.suse.com/sbp/sap -> {sapNW} High Availability Cluster 7.40 - Setup Guide)
+(https://documentation.suse.com/sbp/sap -> {sapS4} - Enqueue Replication 2 High Availability Cluster - Setup Guide),
 the cluster integration can be done with a configuration file. Create one configuration file for each SID
 and load them one by one into the cluster. 
 

--- a/adoc/SAP-NetWeaver-7.50-SLE-15-Setup-Guide-AliCloud.adoc
+++ b/adoc/SAP-NetWeaver-7.50-SLE-15-Setup-Guide-AliCloud.adoc
@@ -51,7 +51,7 @@ resources are provided at the {sles4sap} resource
 library: https://www.suse.com/products/sles-for-sap/#resource .
 
 This guide and other SAP-specific best practices documents can be downloaded from
-the documentation portal at https://documentation.suse.com/sbp/all.
+the documentation portal at https://documentation.suse.com/sbp/sap.
 
 Here you can find guides for {SAPHANA} system replication
 automation and HA scenarios for {SAPNw} and {s4hana}.
@@ -135,7 +135,7 @@ because of the focus of the {sapCert} certification.
 If your database is {sapHana}, we recommend to set up the performance-optimized
 system replication scenario using our automation solution {sapHanaSR}. The
 {sapHanaSR} automation should be set up in an own two node cluster. The setup is
-described in a separate best practices document available at http://documentation.suse.com/sbp/all.
+described in a separate best practices document available at http://documentation.suse.com/sbp/sap.
 In case of using ASE database together with an HADR setup, there is an example in this document.
 
 .Three systems for the certification setup

--- a/adoc/SAP_HA740_SetupGuide_AWS.adoc
+++ b/adoc/SAP_HA740_SetupGuide_AWS.adoc
@@ -145,7 +145,7 @@ resources at the SUSE Linux Enterprise Server for SAP Applications resource
 library: https://www.suse.com/products/sles-for-sap/resource-library/.
 
 This guide and other SAP specific best practices can be downloaded via
-https://documentation.suse.com/sbp/all/.
+https://documentation.suse.com/sbp/sap/.
 Here you can find guides for {SAPHANA} system replication
 automation and HA scenarios for {SAPNw} and {s4hana}.
 

--- a/adoc/SAP_HA740_SetupGuide_SLE12.adoc
+++ b/adoc/SAP_HA740_SetupGuide_SLE12.adoc
@@ -155,7 +155,7 @@ resources are provided at the {sles4sap} resource
 library: https://www.suse.com/products/sles-for-sap/#resource .
 
 This guide and other SAP-specific best practices documents can be downloaded from 
-the documentation portal at https://documentation.suse.com/sbp/all.
+the documentation portal at https://documentation.suse.com/sbp/sap.
 
 Here you can find guides for {SAPHANA} system replication
 automation and HA scenarios for {SAPNw} and {s4hana}.
@@ -239,7 +239,7 @@ because of the focus of the {sapCert} certification.
 If your database is {sapHana}, we recommend to set up the performance optimized
 system replication scenario using our automation solution {sapHanaSR}. The
 {sapHanaSR} automation should be set up in an own two node cluster. The setup is
-described in a separate best practices document available at http://documentation.suse.com/sbp/all.
+described in a separate best practices document available at http://documentation.suse.com/sbp/sap.
 
 .Three systems for the certification setup
 image::sles4sap_nw740_3nodes.svg[SVG]

--- a/adoc/SAP_HA740_SetupGuide_SLE15.adoc
+++ b/adoc/SAP_HA740_SetupGuide_SLE15.adoc
@@ -157,7 +157,7 @@ resources are provided at the {sles4sap} resource
 library: https://www.suse.com/products/sles-for-sap/#resource .
 
 This guide and other SAP-specific best practices documents can be downloaded from
-the documentation portal at https://documentation.suse.com/sbp/all .
+the documentation portal at https://documentation.suse.com/sbp/sap .
 
 Here you can find guides for {SAPHANA} system replication
 automation and HA scenarios for {SAPNw} and {s4hana}.
@@ -241,7 +241,7 @@ because of the focus of the {sapCert} certification.
 If your database is {sapHana}, we recommend to set up the performance optimized
 system replication scenario using our automation solution {sapHanaSR}. The
 {sapHanaSR} automation should be set up in an own two node cluster. The setup is
-described in a separate best practice document available at http://documentation.suse.com/sbp/all.
+described in a separate best practice document available at http://documentation.suse.com/sbp/sap.
 
 .Three systems for the certification setup
 image::sles4sap_nw740_3nodes.svg[SVG]

--- a/adoc/SAP_S4HA10_SetupGuide_SLE12.adoc
+++ b/adoc/SAP_S4HA10_SetupGuide_SLE12.adoc
@@ -67,7 +67,7 @@ For the latest product documentation updates, see https://documentation.suse.com
 More whitepapers, guides and best practices documents referring to SUSE Linux Enterprise Server and SAP can be
 found and downloaded at the SUSE Best Practices Web page:
 
-https://documentation.suse.com/sbp/all/
+https://documentation.suse.com/sbp/sap/
 
 Here you can access guides for {SAPHANA} system replication
 automation and High Availability (HA) scenarios for {SAPNw} and {s4hana}.

--- a/adoc/SAP_S4HA10_SetupGuide_SLE15.adoc
+++ b/adoc/SAP_S4HA10_SetupGuide_SLE15.adoc
@@ -75,7 +75,7 @@ For the latest product documentation updates, see https://documentation.suse.com
 More whitepapers, guides and best practices documents referring to SUSE Linux Enterprise Server and SAP can be
 found and downloaded at the SUSE Best Practices Web page:
 
-https://documentation.suse.com/sbp/all/
+https://documentation.suse.com/sbp/sap/
 
 Here you can access guides for {SAPHANA} system replication
 automation and High Availability (HA) scenarios for {SAPNw} and {s4hana}.

--- a/adoc/SAP_S4HA10_Setup_SimpleMount_SLE15.adoc
+++ b/adoc/SAP_S4HA10_Setup_SimpleMount_SLE15.adoc
@@ -95,7 +95,7 @@ Find white-papers, best-practices guides, and other resources at the
 https://www.suse.com/products/sles-for-sap/resource-library/
 
 - SUSE Best Practices Web page:
-https://documentation.suse.com/sbp/all/
+https://documentation.suse.com/sbp/sap/
 
 Lastly, there are manual pages shipped with the product.
 

--- a/adoc/SLES4SAP-HANAonKVM-15SP2.adoc
+++ b/adoc/SLES4SAP-HANAonKVM-15SP2.adoc
@@ -1592,7 +1592,7 @@ or other application using the libvirt API.
 [[_sec_resources]]
 === Resources
 
-* https://documentation.suse.com/sbp/all/[SUSE Best Practices]
+* https://documentation.suse.com/sbp/sap/[SUSE Best Practices]
 * https://documentation.suse.com/sles/15-SP2/html/SLES-all/book-virt.html[SUSE Virtualization Guide for SUSE Linux Enterprise Server 15]
 * {launchpadnotes}3120786[SAP Note 3120786 - "SAP HANA on SUSE KVM Virtualization with SLES 15 SP2"]
 * {launchPadNotes}2284516[SAP Note 2284516 - "SAP HANA virtualized on SUSE Linux Enterprise Hypervisors"]

--- a/adoc/SLES4SAP-hana-scaleOut-PerfOpt-12.adoc
+++ b/adoc/SLES4SAP-hana-scaleOut-PerfOpt-12.adoc
@@ -74,7 +74,7 @@ Find white-papers, best-practices guides, and other resources at the
 - {sles4sap} resource library:
 https://www.suse.com/products/sles-for-sap/resource-library/
 - SUSE Best Practices Web page:
-https://documentation.suse.com/sbp/all/
+https://documentation.suse.com/sbp/sap/
 
 // Standard SUSE includes
 === Feedback
@@ -2474,7 +2474,7 @@ intention, this could trigger a takeover.
 === {SUSE} Best Practices and more
 
 Best Practices for {sles} for SAP Applications 12::
-https://documentation.suse.com/sbp/all/
+https://documentation.suse.com/sbp/sap/
 
 SAP blog article::
 http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution[Fail-Safe Operation of {SAPHANA}*: {SUSE} Extends Its High-Availability Solution]

--- a/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
@@ -77,7 +77,7 @@ Find white-papers, best-practices guides, and other resources at the
 - {sles4sap} resource library:
 https://www.suse.com/products/sles-for-sap/resource-library/
 - SUSE Best Practices Web page:
-https://documentation.suse.com/sbp/all/
+https://documentation.suse.com/sbp/sap/
 
 // Standard SUSE includes
 === Feedback
@@ -2484,7 +2484,7 @@ intention, this could trigger a takeover.
 === {SUSE} Best Practices and more
 
 Best Practices for {sles} for SAP Applications 15::
- https://documentation.suse.com/sbp/all/
+ https://documentation.suse.com/sbp/sap/
 
 Blog series of articles under the tag #towardsZeroDowntime::
  https://www.suse.com/c/tag/towardszerodowntime/

--- a/adoc/SLES4SAP-hana-sr-guide-CostOpt-12.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-CostOpt-12.adoc
@@ -3940,7 +3940,7 @@ Set the standby node to be online again.
 === SUSE Best Practices and More
 
 Best Practices for SAP on SUSE Linux Enterprise::
- https://documentation.suse.com/sbp/all/
+ https://documentation.suse.com/sbp/sap/
 
 Blog series of articles under the tag #towardsZeroDowntime::
  https://www.suse.com/c/tag/towardszerodowntime/

--- a/adoc/SLES4SAP-hana-sr-guide-CostOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-CostOpt-15.adoc
@@ -3906,7 +3906,7 @@ Set the standby node to be online again.
 === SUSE Best Practices and more
 
 Best Practices for SAP on SUSE Linux Enterprise::
- https://documentation.suse.com/sbp/all/
+ https://documentation.suse.com/sbp/sap/
 
 Blog series of articles under the tag #towardsZeroDowntime::
  https://www.suse.com/c/tag/towardszerodowntime/

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12-AWS.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12-AWS.adoc
@@ -3086,7 +3086,7 @@ Blog series #towardsZeroDowntime::
  https://www.suse.com/c/tag/towardszerodowntime/
 
 Best Practices for SAP on SUSE Linux Enterprise::
- https://documentation.suse.com/sbp/all/
+ https://documentation.suse.com/sbp/sap/
 
 Blog in 2014 - Fail-Safe Operation of SAP HANA®: SUSE Extends Its High Availability Solution::
  http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12-Alicloud.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12-Alicloud.adoc
@@ -38,8 +38,7 @@ The SUSE High Availability Extension is a high availability solution based on Co
 
 For details, refer to the latest version of the document *SAP HANA SR Performance Optimized Scenario* at the SUSE documentation Web page:  
 
-https://documentation.suse.com/sbp/all/
-
+https://documentation.suse.com/sbp/sap/
 
 === Architecture Overview
 This document guides you on how to deploy an SAP HANA High Availability (HA) solution cross different Zones. The following list contains a brief architecture overview:

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12.adoc
@@ -2785,7 +2785,7 @@ Blog series #towardsZeroDowntime::
  https://www.suse.com/c/tag/towardszerodowntime/
 
 Best Practices for SAP on SUSE Linux Enterprise::
- https://documentation.suse.com/sbp/all/
+ https://documentation.suse.com/sbp/sap/
 
 Blog in 2014 - Fail-Safe Operation of SAP HANA®: SUSE Extends Its High Availability Solution::
  http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15-AWS.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15-AWS.adoc
@@ -3025,7 +3025,7 @@ Blog series #towardsZeroDowntime::
  https://www.suse.com/c/tag/towardszerodowntime/
 
 Best Practices for SAP on SUSE Linux Enterprise::
- https://documentation.suse.com/sbp/all/
+ https://documentation.suse.com/sbp/sap/
 
 Blog in 2014 - Fail-Safe Operation of SAP HANA®: SUSE Extends Its High Availability Solution::
  http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -2793,7 +2793,7 @@ Blog series #towardsZeroDowntime::
  https://www.suse.com/c/tag/towardszerodowntime/
 
 Best Practices for SAP on SUSE Linux Enterprise::
- https://documentation.suse.com/sbp/all/
+ https://documentation.suse.com/sbp/sap/
 
 Blog in 2014 - Fail-Safe Operation of SAP HANA®: SUSE Extends Its High Availability Solution::
  http://scn.sap.com/community/hana-in-memory/blog/2014/04/04/fail-safe-operation-of-sap-hana-suse-extends-its-high-availability-solution

--- a/adoc/Var_SLES4SAP-hana-scaleOut-PerfOpt-15.txt
+++ b/adoc/Var_SLES4SAP-hana-scaleOut-PerfOpt-15.txt
@@ -198,7 +198,7 @@
 :persMemDoc: https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-nvdimm.html
 :launchPadNotes: https://launchpad.support.sap.com/#/notes/
 :susedoc: https://documentation.suse.com/
-:reslibrary: https://documentation.suse.com/sbp/all/
+:reslibrary: https://documentation.suse.com/sbp/sap/
 :sumalandingpage: https://www.suse.com/products/suse-manager/
 :sumadoc: https://documentation.suse.com/external-tree/en-us/suma/4.1/suse-manager/index.html
 :scclandingpage: https://scc.suse.com/

--- a/adoc/Var_SLES4SAP-hana-sr-guide-CostOpt-12.txt
+++ b/adoc/Var_SLES4SAP-hana-sr-guide-CostOpt-12.txt
@@ -188,7 +188,7 @@
 :autoYastGuide12: https://documentation.suse.com/sles/12-SP4/html/SLES-all/book-autoyast.html
 :haAdminGuide12: https://documentation.suse.com/sle-ha/12-SP4/html/SLE-HA-all/book-sleha.html
 :launchPadNotes: https://launchpad.support.sap.com/#/notes/
-:reslibrary: https://documentation.suse.com/sbp/all/
+:reslibrary: https://documentation.suse.com/sbp/sap/
 :refsidadm: <sid>adm
 :refHost1: <host1>
 :refInst: <instanceNumber>

--- a/adoc/Var_SLES4SAP-hana-sr-guide-CostOpt-15.txt
+++ b/adoc/Var_SLES4SAP-hana-sr-guide-CostOpt-15.txt
@@ -202,7 +202,7 @@
 :storageGuide15: https://documentation.suse.com/sles/15-SP2/single-html/SLES-storage/
 :launchPadNotes: https://launchpad.support.sap.com/#/notes/
 :susedoc: https://documentation.suse.com/
-:reslibrary: https://documentation.suse.com/sbp/all/
+:reslibrary: https://documentation.suse.com/sbp/sap/
 :sumalandingpage: https://www.suse.com/products/suse-manager/
 :sumadoc: https://documentation.suse.com/external-tree/en-us/suma/4.1/suse-manager/index.html
 :scclandingpage: https://scc.suse.com/

--- a/adoc/Var_SLES4SAP-hana-sr-guide-PerfOpt-12.txt
+++ b/adoc/Var_SLES4SAP-hana-sr-guide-PerfOpt-12.txt
@@ -185,7 +185,7 @@
 :autoYastGuide12: https://documentation.suse.com/sles/12-SP4/html/SLES-all/book-autoyast.html
 :haAdminGuide12: https://documentation.suse.com/sle-ha/12-SP4/html/SLE-HA-all/book-sleha.html
 :launchPadNotes: https://launchpad.support.sap.com/#/notes/
-:reslibrary: https://documentation.suse.com/sbp/all/
+:reslibrary: https://documentation.suse.com/sbp/sap/
 :refsidadm: <sidadm>
 :refHost1: <host1>
 :refInst: <instanceNumber>

--- a/adoc/Var_SLES4SAP-hana-sr-guide-PerfOpt-15.txt
+++ b/adoc/Var_SLES4SAP-hana-sr-guide-PerfOpt-15.txt
@@ -185,7 +185,7 @@
 :autoYastGuide15: https://documentation.suse.com/sles/15-SP1/html/SLES-all/book-autoyast.html
 :haAdminGuide15: https://documentation.suse.com/sle-ha/15-SP1/single-html/SLE-HA-guide/
 :launchPadNotes: https://launchpad.support.sap.com/#/notes/
-:reslibrary: https://documentation.suse.com/sbp/all/
+:reslibrary: https://documentation.suse.com/sbp/sap/
 :refsidadm: <sid>adm
 :refHost1: <host1>
 :refInst: <instanceNumber>


### PR DESCRIPTION
Fix for various sap related best practices which still pointed to the old landing page (all).
Two documents have been converted from dos2unix because of mixed-mode line termination.