### PR TITLE
[doc] 7.1  Ceph MONS - Fixed YAML indentation in Ceph MON placement section

### DIFF
--- a/xml/MAIN-SBP-rook-ceph-kubernetes.xml
+++ b/xml/MAIN-SBP-rook-ceph-kubernetes.xml
@@ -518,28 +518,28 @@ nodeAffinity:​
 			<screen>
 cluster.yaml:
 placement:
-	mon:
-# ... nodeAffinity from above ...
-podAntiAffinity:​
-  preferredDuringSchedulingIgnoredDuringExecution:​
-    - weight:80​
-      podAffinityTerm:​
-        labelSelector:​
-          matchLabels:​
-            app:rook-ceph-mon​
-        topologyKey:topology.rook.io/room​
-    - weight:90​
-      podAffinityTerm:​
-        labelSelector:​
-          matchLabels:​
-            app:rook-ceph-mon​
-        topologyKey:topology.rook.io/rack​
-		- weight: 100​
-		  podAffinityTerm:​
-		    labelSelector:​
-		      matchLabels:​
-		        app: rook-ceph-mon​
-		    topologyKey: kubernetes.io/hostname​
+  mon:
+    # ... nodeAffinity from above ...
+    podAntiAffinity:​
+      preferredDuringSchedulingIgnoredDuringExecution:​
+        - weight:80​
+          podAffinityTerm:​
+            labelSelector:​
+              matchLabels:​
+                app:rook-ceph-mon​
+            topologyKey:topology.rook.io/room​
+        - weight:90​
+          podAffinityTerm:​
+            labelSelector:​
+              matchLabels:​
+                app:rook-ceph-mon​
+            topologyKey:topology.rook.io/rack​
+        - weight: 100​
+          podAffinityTerm:​
+            labelSelector:​
+              matchLabels:​
+                app: rook-ceph-mon​
+            topologyKey: kubernetes.io/hostname​
 </screen>
 
 			<note>


### PR DESCRIPTION
7.1  Ceph MONS:

https://documentation.suse.com/sbp/all/single-html/SBP-rook-ceph-kubernetes/index.html#ceph-mons

Mostly replaced tabs with spaces in YAML sample