### PR TITLE
RocketChat -> Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Thank you for contributing to this repo. Please adhere to the following guidelin
   (see instructions below) to verify and build the files. Travis CI only validates, and does not ensure the XML builds
   are correct.
 
-* Implement any required changes, or fix any merge conflicts if relevant. If you have any questions, ping a documentation team
-  member in #susedoc on RocketChat.
+* Implement any required changes, or fix any merge conflicts if relevant. If you have any questions and are a SUSE employee, ping a documentation team member in #team-suse-docs on Slack.
 
 
 ## Editing DocBook


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>

Small touch-up to refer to the correct chat room.
I wonder however, is there a place for non-staffers to reach out?

Best,
Georg