### PR TITLE
Don't publish SBPs on susedoc.github.io anymore

### DIFF
--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -82,21 +82,5 @@ jobs:
           path: ${{ steps.build-dc.outputs.artifact-dir }}/*
           retention-days: 3
 
-
-  publish:
-    runs-on: ubuntu-latest
-    if: ${{ success() }}
-    needs: [select-dc-files, build-html]
-    continue-on-error: true
-    steps:
-      - name: Downloading all build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifact-dir
-      - name: Publishing builds on susedoc.github.io
-        uses: openSUSE/doc-ci@gha-publish
-        env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY_SBP }}
-        with:
-          artifact-path: artifact-dir
-          relevant-dirs: ${{ needs.select-dc-files.outputs.relevant-branches }}
+# In contrast to other doc repos, we don't publish the SBPs to
+# susedoc.github.io anymore.


### PR DESCRIPTION
Related:

* Add redirect: SUSEdoc/suse-best-practices@3a72d35f
* Remove any SBPs in config: SUSEdoc/susedoc.github.io@107df46e