### PR TITLE
fixed typo mentioned in https://github.com/SUSE/suse-best-practices/issues/308

### DIFF
--- a/adoc/OS_Security_Hardening_Guide_for_SAP_HANA_SLES12.adoc
+++ b/adoc/OS_Security_Hardening_Guide_for_SAP_HANA_SLES12.adoc
@@ -312,7 +312,7 @@ Impact::
 Priority:: Medium
 
 Disabling `ctrl-alt-del`
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 Description::
 Prevent reboot of a system via serial console and/or external keyboard
 

--- a/adoc/OS_Security_Hardening_Guide_for_SAP_HANA_SLES15.adoc
+++ b/adoc/OS_Security_Hardening_Guide_for_SAP_HANA_SLES15.adoc
@@ -296,7 +296,7 @@ Priority::
 Medium
 
 Disabling `ctrl-alt-del`
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 Description::
 This prevents a reboot of a system via serial console and/or external keyboard.
 
@@ -1024,8 +1024,8 @@ Recommendation::
 This is only a good strategy if important security updates are installed outside of the usual maintenance windows.
 
 
-Selectively installating new updates and patches
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Selectively installing new updates and patches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Description:: 
 A selective installation of patches and updates, for example of security updates only, further reduces the probability of installing problematic updates. 
 This strategy is frequently combined with updating systems on a regular basis. 


### PR DESCRIPTION
Typo has been fixed. "Disabling Ctrl-Alt-Del" is now a section title again.

It was introduced during the changes in:

commit 98086b6d2133cd80e8a55c0438e9c7733172a22f
Author: Meike Chabowski <meike.chabowski@suse.com>
Date:   Thu Feb 10 17:49:01 2022 +0100

    Changed all section titles to sentence style
    
    Since a while now, and according to the documentation Style Guide, we
    are not capitalizing section titles anymore, but use sentence-style
    titles. Changed that for all three documents.
...    
