### PR TITLE
Fixes the command to create a submit request in osc

### DIFF
--- a/xml/MAIN-SBP-Quilting-OSC.xml
+++ b/xml/MAIN-SBP-Quilting-OSC.xml
@@ -1835,7 +1835,7 @@
             </listitem>
             <listitem>
                 <para>
-                    <command>osc submit</command>
+                    <command>osc submitrequest</command>
                 </para>
             </listitem>
         </orderedlist>


### PR DESCRIPTION
The right command is `osc submitrequest`.