### PR TITLE
CI: Use @v3 GH Actions to avoid warnings

### DIFF
--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -21,7 +21,7 @@ jobs:
       allow-build: ${{ steps.select-dc-build.outputs.allow-build }}
       relevant-branches: ${{ steps.select-dc-build.outputs.relevant-branches }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Checking basic soundness of DC files
         uses: openSUSE/doc-ci@gha-select-dcs
@@ -50,7 +50,7 @@ jobs:
       matrix:
         dc-files: ${{ fromJson(needs.select-dc-files.outputs.validate-list) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Validating DC file(s) ${{ matrix.dc-files }}
         uses: openSUSE/doc-ci@gha-validate
         with:
@@ -69,14 +69,14 @@ jobs:
       matrix:
         dc-files: ${{ fromJson(needs.select-dc-files.outputs.build-list) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Building DC file(s) ${{ matrix.dc-files }}
         id: build-dc
         uses: openSUSE/doc-ci@gha-build
         with:
           dc-files: ${{ matrix.dc-files }}
       - name: Uploading builds as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build-dc.outputs.artifact-name }}
           path: ${{ steps.build-dc.outputs.artifact-dir }}/*


### PR DESCRIPTION
For `action/checkout`, `actions/upload-artifact`, `actions/download-artifact`