### PR TITLE
Fix typo in the command to check the SAP hostagent

### DIFF
--- a/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
@@ -1027,7 +1027,7 @@ to check the SAP hostagent:
 ----
 [subs="attributes,quotes"]
 ----
-# /usr/sap/hostctrl/exe/saphostctrl ­function ListInstances
+# /usr/sap/hostctrl/exe/saphostctrl -­function ListInstances
 Inst Info : {sapsid} ­ {sapino} ­ {sapnode1} ­ 753, patch 819, changelist 2069355
 ----
 The SystemV style sapinit is running and the hostagent recognises the installed


### PR DESCRIPTION
The right command is

/usr/sap/hostctrl/exe/saphostctrl -function ListInstances