### PR TITLE
Switch to DocBook 5 to validate some papers

### DIFF
--- a/DC-SBP-AMD-EPYC-2-SLES15SP1
+++ b/DC-SBP-AMD-EPYC-2-SLES15SP1
@@ -23,4 +23,5 @@ FALLBACK_STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
 

--- a/DC-SBP-AMD-EPYC-3-SLES15SP2
+++ b/DC-SBP-AMD-EPYC-3-SLES15SP2
@@ -50,3 +50,6 @@ FALLBACK_STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 ## following line
 ##
 #export DOCCONF_NAME=$BASH_SOURCE
+
+
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"

--- a/DC-SBP-AMD-EPYC-4-SLES15SP4
+++ b/DC-SBP-AMD-EPYC-4-SLES15SP4
@@ -50,3 +50,5 @@ FALLBACK_STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 ## following line
 ##
 #export DOCCONF_NAME=$BASH_SOURCE
+
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"

--- a/DC-SBP-GCC-10
+++ b/DC-SBP-GCC-10
@@ -24,3 +24,5 @@ FALLBACK_STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 #EPUB_CSS=""
 
 XSLTPARAM="--stringparam publishing.series=sbp"
+
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"

--- a/DC-SBP-GCC-11
+++ b/DC-SBP-GCC-11
@@ -24,3 +24,5 @@ FALLBACK_STYLEROOT=/usr/share/xml/docbook/stylesheet/suse2021-ns
 #EPUB_CSS=""
 
 XSLTPARAM="--stringparam publishing.series=sbp"
+
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"


### PR DESCRIPTION
Some papers didn't validate when switching GHA gha-validate from GeekoDoc version 1 to version 2 as default.