### PR TITLE
Correct DOCBOOK5_RNG_URI & STYLEROOT

### DIFF
--- a/l10n/ja-jp/DC-SBP-SAP-HANA-PerOpt-HA-Azure
+++ b/l10n/ja-jp/DC-SBP-SAP-HANA-PerOpt-HA-Azure
@@ -1,6 +1,6 @@
 MAIN="SBP-SAP-HANA-PerOpt-HA-Azure.xml"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
@@ -8,4 +8,4 @@ XSLTPARAM="--stringparam publishing.series=sbp"
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.2/docbookxi.rnc"

--- a/l10n/ja-jp/DC-SBP-Spectre-Meltdown-L1TF
+++ b/l10n/ja-jp/DC-SBP-Spectre-Meltdown-L1TF
@@ -5,5 +5,5 @@
 MAIN="MAIN-SBP-Spectre-Meltdown-L1TF.xml"
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 ## STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"

--- a/l10n/ja-jp/DC-SBP-susemanager
+++ b/l10n/ja-jp/DC-SBP-susemanager
@@ -5,4 +5,4 @@
 MAIN="MAIN-SBP-susemanager.xml"
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"

--- a/l10n/ja-jp/DC-SLES-SAP-hana-scaleOut-PerfOpt-12-AWS
+++ b/l10n/ja-jp/DC-SLES-SAP-hana-scaleOut-PerfOpt-12-AWS
@@ -1,12 +1,12 @@
 MAIN="SLES-SAP-hana-scaleOut-PerfOpt-12-AWS.xml"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 

--- a/l10n/ja-jp/DC-SLES4SAP-hana-sr-guide-PerfOpt-15
+++ b/l10n/ja-jp/DC-SLES4SAP-hana-sr-guide-PerfOpt-15
@@ -1,6 +1,6 @@
 MAIN="SLES4SAP-hana-sr-guide-PerfOpt-15.xml"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 XSLTPARAM="--stringparam publishing.series=sbp"
 
 #STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
@@ -10,5 +10,5 @@ XSLTPARAM="--stringparam publishing.series=sbp"
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
-#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.2/docbookxi.rnc"
+#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"

--- a/l10n/ko-kr/DC-RKE2-SAP-DI31
+++ b/l10n/ko-kr/DC-RKE2-SAP-DI31
@@ -7,7 +7,7 @@ MAIN="RKE2-SAP-DI31.xml"
 # ADOC_ATTRIBUTES="--attribute docdate=2021-07-26"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
@@ -15,5 +15,5 @@ XSLTPARAM="--stringparam publishing.series=sbp"
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"
 

--- a/l10n/ko-kr/DC-SAP_HA740_SetupGuide_AWS
+++ b/l10n/ko-kr/DC-SAP_HA740_SetupGuide_AWS
@@ -1,7 +1,7 @@
 MAIN="SAP_HA740_SetupGuide_AWS.xml"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 
 #STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
@@ -11,4 +11,4 @@ XSLTPARAM="--stringparam publishing.series=sbp"
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"

--- a/l10n/ko-kr/DC-SAP_S4HA10_SetupGuide-SLE15
+++ b/l10n/ko-kr/DC-SAP_S4HA10_SetupGuide-SLE15
@@ -1,12 +1,12 @@
 MAIN="SAP_S4HA10_SetupGuide-SLE15.xml"
 
 # stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
-#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.2/docbookxi.rnc"
+#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"

--- a/l10n/ko-kr/DC-SBP-SAP-HANA-PerOpt-HA-Azure
+++ b/l10n/ko-kr/DC-SBP-SAP-HANA-PerOpt-HA-Azure
@@ -1,6 +1,6 @@
 MAIN="SBP-SAP-HANA-PerOpt-HA-Azure.xml"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 
 XSLTPARAM="--stringparam publishing.series=sbp"
 
@@ -8,4 +8,4 @@ XSLTPARAM="--stringparam publishing.series=sbp"
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.2/docbookxi.rnc"

--- a/l10n/ko-kr/DC-SBP-Spectre-Meltdown-L1TF
+++ b/l10n/ko-kr/DC-SBP-Spectre-Meltdown-L1TF
@@ -5,4 +5,4 @@
 MAIN="MAIN-SBP-Spectre-Meltdown-L1TF.xml"
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"

--- a/l10n/ko-kr/DC-SBP-susemanager
+++ b/l10n/ko-kr/DC-SBP-susemanager
@@ -5,4 +5,4 @@
 MAIN="MAIN-SBP-susemanager.xml"
 
 ## Custom Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"

--- a/l10n/ko-kr/DC-SLES4SAP-hana-sr-guide-PerfOpt-15
+++ b/l10n/ko-kr/DC-SLES4SAP-hana-sr-guide-PerfOpt-15
@@ -1,6 +1,6 @@
 MAIN="SLES4SAP-hana-sr-guide-PerfOpt-15.xml"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 XSLTPARAM="--stringparam publishing.series=sbp"
 
 #STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
@@ -10,5 +10,5 @@ XSLTPARAM="--stringparam publishing.series=sbp"
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.1/docbookxi.rnc"
-#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="file:///usr/share/xml/docbook/schema/rng/5.2/docbookxi.rnc"
+#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"

--- a/l10n/ko-kr/DC-SLES4SAP-hana-sr-guide-PerfOpt-15_AWS
+++ b/l10n/ko-kr/DC-SLES4SAP-hana-sr-guide-PerfOpt-15_AWS
@@ -1,10 +1,10 @@
 MAIN="SLES4SAP-hana-sr-guide-PerfOpt-15_AWS.xml"
 
 #stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-sbp-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/sbp"
 XSLTPARAM="--stringparam publishing.series=sbp"
 
 ROLE="sbp"
 PROFROLE="sbp"
 
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.1/rng/docbookxi.rnc"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rnc"


### PR DESCRIPTION
* `DOCBOOK5_RNG_URI` should point to DocBook 5.2
* `STYLEROOT` should point to the new SBP stylesheets