### PR TITLE
SLES-for-SAP HA guides update - mainly native systemd integration

### DIFF
--- a/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
@@ -2571,52 +2571,13 @@ intention, this could trigger a takeover.
 |===
 
 
-// TODO PRIO2: gett the below systemd example from common include file
 [[cha.hanasr-example-systemv]]
 === Example for checking legacy SystemV integration
+include::SLES4SAP-hana-systemv-appendix.adoc[]
 
-Check if the SAP hostagent is installed on all cluster nodes.
-As Linux user _root_, use the commands `systemctl` and `saphostctrl`
-to check the SAP hostagent:
-
-[subs="attributes,quotes"]
-----
-# systemctl status sapinit
-* sapinit.service - LSB: Start the sapstartsrv
-   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
-   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
-     Docs: man:systemd-sysv-generator(8)
-    Tasks: 0
-   CGroup: /system.slice/sapinit.service
-# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
-Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
-----
-The SystemV style sapinit is running and the hostagent recognises the installed
-database.
-
-As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
-overview of running {HANA} processes. The output of `HDB info` should
-be similar to the output shown below:
-
-[subs="attributes,quotes"]
-----
-{sapnode1}:{sapssid}adm> HDB info
-USER          PID     PPID  ... COMMAND
-{sapssid}adm      13017    ... -sh
-{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
-{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
-{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
-{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
-{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8756    ...      \_ hdbnameserver
-{sapssid}adm       9031    ...      \_ hdbcompileserver
-{sapssid}adm       9034    ...      \_ hdbpreprocessor
-{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
-{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
-{sapssid}adm       9531    ...      \_ hdbwebdispatcher
-{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
-----
+++++
+<?pdfpagebreak?>
+++++
 
 
 [[app.hana-sr.information]]
@@ -2627,8 +2588,8 @@ For more detailed information, have a look at the documents listed below.
 // SUSE docu, manual pages, TIDs and blogs. SAP guides and notes.
 :leveloffset: 2
 include::SAPNotes_HANA20_15.adoc[]
-
 :leveloffset: 0
+
 === Pacemaker
 
 Pacemaker Project Documentation::
@@ -2661,7 +2622,6 @@ subs attribute accepts any of the following (in a list):
 <?pdfpagebreak?>
 ++++
 
-:leveloffset: 0
 // Standard SUSE Best Practices includes
 == Legal notice
 include::common_sbp_legal_notice.adoc[]
@@ -2671,7 +2631,6 @@ include::common_sbp_legal_notice.adoc[]
 ++++
 
 // Standard SUSE Best Practices includes
-:leveloffset: 0
 include::common_gfdl1.2_i.adoc[]
 
 //

--- a/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
@@ -8,9 +8,6 @@ include::Var_SLES4SAP-hana-scaleOut-PerfOpt-15-param.txt[]
 
 = {SAPHANA} System Replication Scale-Out - Performance Optimized Scenario
 
-:Revision: 0.2
-// TODO PRIO3: revision here, or at very bottom? see very bottom...
-// TODO PRIO3: check what we can borrow from AWS scale-out 15 guide
 // TODO PRIO3: use variables like {usecase}, as in scale-up
 
 ////
@@ -372,15 +369,15 @@ following configurations and parameters:
   supported. But the cost optimized and MCOS scenarios are currently not supported.
 * The _{sapHostAgent}_ must be running. _{sapHostAgent}_ is needed to translate
   between the system node names and SAP host names used during the installation
-  of {HANA}. For SystemV style, the sapinit script needs to be active.
-// TODO PRIO1: publish the below, once SAP ships systemd integration for HANA
-// For systemd style, the
-// services saphostagent and SAP<SID>_<INO> can stay enabled. The systemd enabled
-// saphostagent and instance´s sapstartsrv is supported from SAPHanaSR-ScaleOut 0.181 onwards.
-// Refer to the OS documentation for the systemd version. Refer to {SAP}
-// documentation for the {HANA} version. Combining systemd style hostagent with
-// SystemV style instance is allowed. However, all nodes in one Linux cluster have to
-// use the same style.
+  of {saphana}.
+** For SystemV style, the sapinit script needs to be active.
+** For systemd style, the services saphostagent and SAP<SID>_<INO> can stay enabled.
+The systemd enabled saphostagent and instance´s sapstartsrv is supported from SAPHanaSR-ScaleOut 0.181 onwards.
+Refer to the OS documentation for the systemd version.
+{HANA} comes with native systemd integration as default starting with version 2.0 SPS07. 
+Refer to {sap} documentation for the {sap} HANA version.
+** Combining systemd style hostagent with SystemV style instance is allowed.
+However, all nodes in one Linux cluster have to use the same style.
 * All {HANA} instances controlled by the cluster must not be activated via
   _sapinit_ auto-start.
 * The replication mode should be either 'sync' or 'syncmem'. But 'async' is not
@@ -595,6 +592,7 @@ The SAP note {sapnoteprep} explains three ways to implementing the settings.
 ====
 
 ==== Enabling SSH access via public key (optional)
+
 Public key authentication provides SSH users access to their servers without entering their passwords.
 SSH keys are also more secure than passwords, because the private key used to secure the connection
 is never shared. Private keys can also be encrypted. Their encrypted contents cannot easily be read.
@@ -798,7 +796,14 @@ synchronization.
 image::SAPHanaSR-ScaleOut-Plan-Phase3.svg[scaledwidth="100%"]
 
 [[SAPHanaInst]]The infrastructure is set up. Now install the {HANA} database on
-both sites. In a cluster a machine is also called a _node_.
+both sites. This chapter summarizes the test environment.
+In a cluster a machine is also called a _node_.
+Always use the official documentation from {SAP} to install {HANA} and to set up
+the system replication.
+
+This guide shows {HANA} and saphostagent with native systemd integration.
+An example for legacy SystemV is outlined in the appendix
+<<cha.hanasr-example-systemv>>.
 
 .Procedure
 
@@ -958,9 +963,6 @@ The second example use the modified template file as answering file.
 ----
 ==============================
 
-// TODO PRIO1: publish the below, once SAP ships systemd integration for HANA
-// begin systemd style
-////
 === Check if the SAP hostagent is installed on all {HANA} nodes
 
 Check if the native systemd enabled SAP hostagent and instance sapstartsrv
@@ -979,6 +981,8 @@ saptune.service enabled
 ----
 The mandatory `saphostagent` service is enabled. This is the installation default.
 Some more {sap} related services might be enabled, e.g. the recommended `saptune`.
+
+The instance service SAP<SID>_<NR>.service needs to be enabled as well.
 
 [subs="attributes,quotes"]
 ----
@@ -1014,123 +1018,47 @@ Unit SAP.slice (/SAP.slice):
   ├─31479 hdbnameserver
   └─32201 hdbrsutil --start --port 31001 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1644426203
 ----
-The SAP hostagent `saphostagent.service` and the instance´s sapstartsrv `SAP{sapsid}_{sapino}.service`
-are running in the `SAP.slice`.
+The SAP hostagent `saphostagent.service` and the instance´s sapstartsrv
+`SAP{sapsid}_{sapino}.service` are running in the `SAP.slice`.
 See also manual pages systemctl(8) and systemd-cgls(8) for details.
-////
-// end systemd style
-// TODO PRIO1: merge with HANA checks from below hostagent, once SAP ships systemd integration for HANA
 
-=== Check if the SAP hostagent is installed on all {HANA} nodes
+Use the python script _landscapeHostConfiguration.py_ to show the status of
+an entire {saphana} site.
+The landscape host configuration is shown with a line per {saphana} host.
+Query the host roles (as user {refsidadm}):
 
-Check if the SAP hostagent is installed on all {HANA} nodes.
-If not, install and enable it now.
-
-As Linux user _root_ run the command _systemctl_ and _saphostctrl_ on all {HANA} nodes
-to check the SAP hostagent:
-
-[subs="attributes,quotes"]
-----
-# systemctl status sapinit
-* sapinit.service - LSB: Start the sapstartsrv
-   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
-   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
-     Docs: man:systemd-sysv-generator(8)
-    Tasks: 0
-   CGroup: /system.slice/sapinit.service
-----
-[subs="attributes,quotes"]
-----
-# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
-Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
-----
-The SystemV style sapinit is running and the hostagent recognises the installed
-database.
-
-=== Verify that both databases are up and running
-
-Verify that *both* database sites are up and all processes of these databases
-are running correctly.
-
-. As Linux user _{refsidadm}_ use the SAP command line tool _HDB_ to get an
-overview of all running {HANA} processes. The output of _HDB info_ should look like
-the example below for *both* sites:
-+
-.Calling  HDB info (as user {refsidadm})
-==============================
-[subs="specialchars,attributes"]
-----
-~> HDB info
-----
-
-The _HDB info_ command lists the processes currently running for that SID.
-
-[subs="specialchars,attributes"]
-----
-USER     PID  ...  COMMAND
-{mysidlc}adm   6561 ...  -csh
-{mysidlc}adm   6635 ...    \_ /bin/sh /usr/sap/{sid}/HDB{inst}/HDB info
-{mysidlc}adm   6658 ...        \_ ps fx -U {sid} -o user,pid,ppid,pcpu,vsz,rss,args
-{mysidlc}adm   5442 ...  sapstart pf=/hana/shared/{sid}/profile/{sid}_HDB{inst}_{mySite1FirstNode}
-{mysidlc}adm   5456 ...   \_ /usr/sap/{sid}/HDB{inst}/{mySite1FirstNode}/trace/hdb.sap{mysidlc}_HDB{inst} -d -nw -f /usr/sap/{mysidlc}/HDB{inst}/suse
-{mysidlc}adm   5482 ...       \_ hdbnameserver
-{mysidlc}adm   5551 ...       \_ hdbpreprocessor
-{mysidlc}adm   5554 ...       \_ hdbcompileserver
-{mysidlc}adm   5583 ...       \_ hdbindexserver
-{mysidlc}adm   5586 ...       \_ hdbstatisticsserver
-{mysidlc}adm   5589 ...       \_ hdbxsengine
-{mysidlc}adm   5944 ...       \_ sapwebdisp_hdb pf=/usr/sap/{sid}/HDB{inst}}/{mySite1FirstNode}/wdisp/sapwebdisp.pfl -f /usr/sap/SL
-{mysidlc}adm   5363 ...  /usr/sap/{sid}/HDB{inst}/exe/sapstartsrv pf=/hana/shared/{sid}/profile/{sid}_HDB{inst}_{mySite2FirstNode} -D -u s
-----
-==============================
-+
-. Use the python script _landscapeHostConfiguration.py_ to show the status of
-an entire {HANA} site.
-+
-.Query the host roles (as user {refsidadm})
-==========
 [subs="specialchars,attributes"]
 ----
 ~> HDBSettings.sh landscapeHostConfiguration.py
-----
 
-The landscape host configuration is shown with a line per {HANA} host.
-
-[subs="specialchars,attributes"]
-----
 | Host   | Host   |... NameServer  | NameServer  | IndexServer | IndexServer
 |        | Active |... Config Role | Actual Role | Config Role | Actual Role
 | ------ | ------ |... ----------- | ----------- | ----------- | -----------
 | {suse01} | yes    |... master 1    | master      | worker      | master
 | {suse03} | yes    |... master 2    | slave       | worker      | slave
-| {suse05} | yes    |... master 3    | slave       | standby     | standby
+| {suse05} | yes    |... master 3    | slave       | worker      | slave
+...
 
 overall host status: ok
 ----
-==========
-+
-. Get an overview of instances of that site (as user {refsidadm})
-+
-.Get the list of instances
-=========
+The number of nodes and the configured roles may vary, depending on your topology.
+
+Get an overview of instances of that site (as user {refsidadm})
+You should get a list of {saphana} instances belonging to that site.
+
 [subs="specialchars,attributes"]
 ----
 ~> sapcontrol -nr {refinst} -function GetSystemInstanceList
-----
-
-You should get a list of {HANA} instances belonging to that site.
-
-[subs="specialchars,attributes"]
-----
-12.06.2021 17:25:16
+25.07.2022 17:25:16
 GetSystemInstanceList
 OK
 hostname, instanceNr, httpPort, httpsPort, startPriority, features, dispstatus
 {suse01}, {inst}, 5{inst}13, 5{inst}14, 0.3, HDB|HDB_WORKER, GREEN
-{suse05}, {inst}, 5{inst}13, 5{inst}14, 0.3, HDB|HDB_WORKER, GREEN
 {suse03}, {inst}, 5{inst}13, 5{inst}14, 0.3, HDB|HDB_WORKER, GREEN
+{suse05}, {inst}, 5{inst}13, 5{inst}14, 0.3, HDB|HDB_WORKER, GREEN
+...
 ----
-=========
+The number of nodes may vary, depending on your topology.
 
 
 == Setting up {HANA} system replication
@@ -1407,6 +1335,8 @@ should be **ACTIVE**.
 | HA1      | suse01 | .. WDF1      | suse02    | .. ROT1      | .. **ACTIVE**
 | HA1      | suse01 | .. WDF1      | suse02    | .. ROT1      | .. **ACTIVE**
 | HA1      | suse03 | .. WDF1      | suse04    | .. ROT1      | .. **ACTIVE**
+| HA1      | suse05 | .. WDF1      | suse06    | .. ROT1      | .. **ACTIVE**
+...
 
 status system replication site "2": ACTIVE
 overall system replication status: ACTIVE
@@ -1426,9 +1356,8 @@ site name: WDF1
 .<<Planning>> <<OsSetup>> <<SAPHanaInst>> <<SAPHanaHsr>> Integration <<Cluster>> <<Testing>>
 image::SAPHanaSR-ScaleOut-Plan-Phase5.svg[scaledwidth="100%"]
 
-[[Integration]]
-This chapter describes what to change on the {saphana} configuration for the
-BW style scale-out scenario.
+[[Integration]] This chapter describes what to change on the {saphana} configuration
+for the BW style scale-out scenario.
 
 This step is mandatory to inform the cluster immediately if the secondary gets
 out of sync. The hook is called by {HANA} using the HA/DR provider interface
@@ -2642,6 +2571,54 @@ intention, this could trigger a takeover.
 |===
 
 
+// TODO PRIO2: gett the below systemd example from common include file
+[[cha.hanasr-example-systemv]]
+=== Example for checking legacy SystemV integration
+
+Check if the SAP hostagent is installed on all cluster nodes.
+As Linux user _root_, use the commands `systemctl` and `saphostctrl`
+to check the SAP hostagent:
+
+[subs="attributes,quotes"]
+----
+# systemctl status sapinit
+* sapinit.service - LSB: Start the sapstartsrv
+   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
+   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
+     Docs: man:systemd-sysv-generator(8)
+    Tasks: 0
+   CGroup: /system.slice/sapinit.service
+# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
+Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
+----
+The SystemV style sapinit is running and the hostagent recognises the installed
+database.
+
+As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
+overview of running {HANA} processes. The output of `HDB info` should
+be similar to the output shown below:
+
+[subs="attributes,quotes"]
+----
+{sapnode1}:{sapssid}adm> HDB info
+USER          PID     PPID  ... COMMAND
+{sapssid}adm      13017    ... -sh
+{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
+{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
+{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
+{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
+{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8756    ...      \_ hdbnameserver
+{sapssid}adm       9031    ...      \_ hdbcompileserver
+{sapssid}adm       9034    ...      \_ hdbpreprocessor
+{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
+{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
+{sapssid}adm       9531    ...      \_ hdbwebdispatcher
+{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
+----
+
+
 [[app.hana-sr.information]]
 == References
 
@@ -2656,7 +2633,6 @@ include::SAPNotes_HANA20_15.adoc[]
 
 Pacemaker Project Documentation::
  https://clusterlabs.org/pacemaker/doc/
-
 
 
 ////
@@ -2681,15 +2657,6 @@ subs attribute accepts any of the following (in a list):
  Global Settings
 ////
 
-////
-// TODO PRIO3: revision history here ot at very top? see very top...
-// Revisions:
-// Revision 0.1 (2021-09-06) copied from 12 and replaced version strings, URLs, SAP notes, TIDs
-// Revision 0.2 (2022-03-08) prepared for systemd, established includes
-////
-
-
-
 ++++
 <?pdfpagebreak?>
 ++++
@@ -2707,3 +2674,11 @@ include::common_sbp_legal_notice.adoc[]
 :leveloffset: 0
 include::common_gfdl1.2_i.adoc[]
 
+//
+// REVISION 0.1 (2021-09-06)
+/	- copied from 12 and replaced version strings, URLs, SAP notes, TIDs
+// REVISION 0.2 (2022-03-08)
+//	- prepared for systemd, established includes
+// REVISION 0.3 (2023-04-03)
+//	- SAP native systemd support is default for HANA 2.0 SPS07
+//

--- a/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
@@ -2985,48 +2985,11 @@ intention, this could trigger a takeover.
 [[cha.hanasr-example-systemv]]
 === Example for checking legacy SystemV integration
 
-Check if the SAP hostagent is installed on all cluster nodes.
-As Linux user _root_, use the commands `systemctl` and `saphostctrl`
-to check the SAP hostagent:
+include::SLES4SAP-hana-systemv-appendix.adoc[]
 
-[subs="attributes,quotes"]
-----
-# systemctl status sapinit
-* sapinit.service - LSB: Start the sapstartsrv
-   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
-   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
-     Docs: man:systemd-sysv-generator(8)
-    Tasks: 0
-   CGroup: /system.slice/sapinit.service
-# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
-Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
-----
-The SystemV style sapinit is running and the hostagent recognises the installed
-database.
-
-As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
-overview of running {HANA} processes. The output of `HDB info` should
-be similar to the output shown below:
-
-[subs="attributes,quotes"]
-----
-{sapnode1}:{sapssid}adm> HDB info
-USER          PID     PPID  ... COMMAND
-{sapssid}adm      13017    ... -sh
-{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
-{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
-{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
-{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
-{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8756    ...      \_ hdbnameserver
-{sapssid}adm       9031    ...      \_ hdbcompileserver
-{sapssid}adm       9034    ...      \_ hdbpreprocessor
-{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
-{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
-{sapssid}adm       9531    ...      \_ hdbwebdispatcher
-{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
-----
+++++
+<?pdfpagebreak?>
+++++
 
 
 [[app.hana-sr.information]]
@@ -3037,8 +3000,8 @@ For more detailed information, have a look at the documents listed below.
 // SUSE docu, manual pages, TIDs and blogs. SAP guides and notes.
 :leveloffset: 2 
 include::SAPNotes_HANA20_15.adoc[]
-
 :leveloffset: 0
+
 === Pacemaker
 
 Pacemaker Project Documentation::
@@ -3047,6 +3010,7 @@ Pacemaker Project Documentation::
 ++++
 <?pdfpagebreak?>
 ++++
+
 
 // Standard SUSE Best Practices includes
 == Legal notice
@@ -3078,6 +3042,7 @@ subs attribute accepts any of the following (in a list):
 <?pdfpagebreak?>
 ++++
 
+// Standard SUSE Best Practices includes
 include::common_gfdl1.2_i.adoc[]
 
 //

--- a/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
@@ -826,6 +826,7 @@ image::SAPHanaSR-ScaleOut-MultiTarget-Plan-Phase3.svg[scaledwidth="100%"]
 
 [[SAPHanaInst]]The infrastructure is set up. Now install the {saphana} database
 at both sites. This chapter summarizes the test environment.
+In a cluster a machine is also called a _node_.
 Always use the official documentation from {SAP} to install {HANA} and to set up
 the system replication.
 
@@ -1011,6 +1012,8 @@ saptune.service enabled
 The mandatory `saphostagent` service is enabled. This is the installation default.
 Some more {sap} related services might be enabled, e.g. the recommended `saptune`.
 
+The instance service SAP<SID>_<NR>.service needs to be enabled as well.
+
 [subs="attributes,quotes"]
 ----
 # systemctl list-unit-files | grep SAP
@@ -1046,7 +1049,8 @@ Unit SAP.slice (/SAP.slice):
   └─32201 hdbrsutil --start --port 31001 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1644426203
 ----
 
-The SAP hostagent `saphostagent.service` and the instance´s sapstartsrv `SAP{sapsid}_{sapino}.service` are running in the `SAP.slice`.
+The SAP hostagent `saphostagent.service` and the instance´s sapstartsrv
+`SAP{sapsid}_{sapino}.service` are running in the `SAP.slice`.
 See also manual pages systemctl(8) and systemd-cgls(8) for details.
 
 Use the python script _landscapeHostConfiguration.py_ to show the status of

--- a/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
@@ -8,9 +8,6 @@ include::Var_SLES4SAP-hana-scaleOut-multiTarget-PerfOpt-15-param.txt[]
 
 = {saphana} System Replication Scale-Out - Multi-Target Performance-Optimized Scenario
 
-:Revision: 0.1
-// TODO PRIO3: revision here, or at very bottom? see very bottom...
-// TODO PRIO3: check what we can borrow from AWS scale-out 15 guide
 // TODO PRIO3: use variables like {usecase}, as in scale-up
 
 ////
@@ -385,15 +382,15 @@ following configurations and parameters:
   supported. The cost optimized and MCOS scenarios are currently not supported.
 * The _{sapHostAgent}_ must be running. _{sapHostAgent}_ is needed to translate
   between the system node names and SAP host names used during the installation
-  of {saphana}. For SystemV style, the sapinit script needs to be active.
-// TODO PRIO1: publish the below, once SAP ships systemd integration for HANA  
-// For systemd style, the
-// services saphostagent and SAP<SID>_<INO> can stay enabled. The systemd enabled
-// saphostagent and instance´s sapstartsrv is supported from SAPHanaSR-ScaleOut 0.181 onwards.
-// Refer to the OS documentation for the systemd version. Refer to {sap}
-// documentation for the {sap} HANA version. Combining systemd style hostagent with
-// SystemV style instance is allowed. However, all nodes in one Linux cluster have to
-// use the same style.
+  of {saphana}.
+** For SystemV style, the sapinit script needs to be active.
+** For systemd style, the services saphostagent and SAP<SID>_<INO> can stay enabled.
+The systemd enabled saphostagent and instance´s sapstartsrv is supported from SAPHanaSR-ScaleOut 0.181 onwards.
+Refer to the OS documentation for the systemd version.
+{HANA} comes with native systemd integration as default starting with version 2.0 SPS07.
+Refer to {sap} documentation for the {sap} HANA version.
+** Combining systemd style hostagent with SystemV style instance is allowed.
+However, all nodes in one Linux cluster have to use the same style.
 * All {saphana} instances controlled by the cluster must not be activated via
   _sapinit_ auto-start.
 * Automated start of {saphana} instances during system boot must be switched
@@ -494,6 +491,7 @@ SAP notes:
 
 
 ==== Installing additional software
+
 {SUSE} delivers with {sles4sap} special resource agents for {saphana}. With the pattern _sap-hana_ the resource
 agent for {saphana} *ScaleUp* is installed. For the *ScaleOut* scenario you need a special resource agent.
 Follow the instructions below on each node if you have installed the systems based on SAP note {sapnoteset15}.
@@ -681,9 +679,9 @@ Collect the public host keys from all other node. For the document at hand, the 
 # ssh-keyscan
 ----
 
-The SSH host key is automatically collected and stored in the file `/root/.ssh/known_host` during the first SSH
-connection. To avoid to confirm the first login with "yes", which accepts the host key, collect and store
-them beforehand.
+The SSH host key is automatically collected and stored in the file `/root/.ssh/known_host`
+during the first SSH connection. To avoid to confirm the first login with "yes", which
+accepts the host key, collect and store them beforehand.
 
 ----
 # ssh-keyscan -t ecdsa-sha2-nistp256 <host1>,<host1 ip> >>.ssh/known_hosts
@@ -826,8 +824,14 @@ synchronization.
 .<<Planning>> <<OsSetup>> SAPHanaInst <<SAPHanaHsr>> <<Integration>> <<Cluster>> <<MultiTarget>> <<Testing>>
 image::SAPHanaSR-ScaleOut-MultiTarget-Plan-Phase3.svg[scaledwidth="100%"]
 
-[[SAPHanaInst]]The infrastructure is set up. Now install the {saphana} database on
-both sites. In a cluster a machine is also called a _node_.
+[[SAPHanaInst]]The infrastructure is set up. Now install the {saphana} database
+at both sites. This chapter summarizes the test environment.
+Always use the official documentation from {SAP} to install {HANA} and to set up
+the system replication.
+
+This guide shows {HANA} and saphostagent with native systemd integration.
+An example for legacy SystemV is outlined in the appendix
+<<cha.hanasr-example-systemv>>.
 
 .Procedure
 
@@ -988,9 +992,6 @@ The second example use the modified template file as answering file.
 ----
 ==============================
 
-// TODO PRIO1: publish the below, once SAP ships systemd integration for HANA
-// begin systemd style
-////
 === Check if the SAP hostagent is installed on all {hana} nodes
 
 Check if the native systemd enabled SAP hostagent and instance sapstartsrv
@@ -1044,90 +1045,19 @@ Unit SAP.slice (/SAP.slice):
   ├─31479 hdbnameserver
   └─32201 hdbrsutil --start --port 31001 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1644426203
 ----
-The SAP hostagent `saphostagent.service` and the instance´s sapstartsrv `SAP{sapsid}_{sapino}.service`
-are running in the `SAP.slice`.
+
+The SAP hostagent `saphostagent.service` and the instance´s sapstartsrv `SAP{sapsid}_{sapino}.service` are running in the `SAP.slice`.
 See also manual pages systemctl(8) and systemd-cgls(8) for details.
-////
-// end systemd style
-// TODO PRIO1: merge with HANA checks from below hostagent, once SAP ships systemd integration for HANA 
 
-=== Check if the SAP hostagent is installed on all {hana} nodes
-
-Check if the SAP hostagent is installed on all {hana} nodes.
-If not, install and enable it now.
-
-As Linux user _root_ run the command _systemctl_ and _saphostctrl_ on all {hana} nodes
-to check the SAP hostagent:
-
-[subs="attributes,quotes"]
-----
-# systemctl status sapinit
-* sapinit.service - LSB: Start the sapstartsrv
-   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
-   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
-     Docs: man:systemd-sysv-generator(8)
-    Tasks: 0
-   CGroup: /system.slice/sapinit.service
-----
-[subs="attributes,quotes"]
-----
-# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
-Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
-----
-The SystemV style sapinit is running and the hostagent recognises the installed
-database.
-
-=== Verify that both databases are up and running
-
-Verify that *both* database sites are up and all processes of these databases
-are running correctly.
-
-. As Linux user _{refsidadm}_ use the SAP command line tool _HDB_ to get an
-overview of all running {saphana} processes. The output of _HDB info_ should look like
-the example below for *both* sites:
-+
-.Calling  HDB info (as user {refsidadm})
-==============================
-[subs="specialchars,attributes"]
-----
-~> HDB info
-----
-
-The _HDB info_ command lists the processes currently running for that SID.
-
-[subs="specialchars,attributes"]
-----
-USER     PID  ...  COMMAND
-{mysidlc}adm   6561 ...  -csh
-{mysidlc}adm   6635 ...    \_ /bin/sh /usr/sap/{sid}/HDB{inst}/HDB info
-{mysidlc}adm   6658 ...        \_ ps fx -U {sid} -o user,pid,ppid,pcpu,vsz,rss,args
-{mysidlc}adm   5442 ...  sapstart pf=/hana/shared/{sid}/profile/{sid}_HDB{inst}_{mySite1FirstNode}
-{mysidlc}adm   5456 ...   \_ /usr/sap/{sid}/HDB{inst}/{mySite1FirstNode}/trace/hdb.sap{mysidlc}_HDB{inst} -d -nw -f /usr/sap/{mysidlc}/HDB{inst}/suse
-{mysidlc}adm   5482 ...       \_ hdbnameserver
-{mysidlc}adm   5551 ...       \_ hdbpreprocessor
-{mysidlc}adm   5554 ...       \_ hdbcompileserver
-{mysidlc}adm   5583 ...       \_ hdbindexserver
-{mysidlc}adm   5586 ...       \_ hdbstatisticsserver
-{mysidlc}adm   5589 ...       \_ hdbxsengine
-{mysidlc}adm   5944 ...       \_ sapwebdisp_hdb pf=/usr/sap/{sid}/HDB{inst}}/{mySite1FirstNode}/wdisp/sapwebdisp.pfl -f /usr/sap/SL
-{mysidlc}adm   5363 ...  /usr/sap/{sid}/HDB{inst}/exe/sapstartsrv pf=/hana/shared/{sid}/profile/{sid}_HDB{inst}_{mySite2FirstNode} -D -u s
-----
-==============================
-+
-. Use the python script _landscapeHostConfiguration.py_ to show the status of
+Use the python script _landscapeHostConfiguration.py_ to show the status of
 an entire {saphana} site.
-+
-.Query the host roles (as user {refsidadm})
-==========
+The landscape host configuration is shown with a line per {saphana} host.
+Query the host roles (as user {refsidadm}):
+
 [subs="specialchars,attributes"]
 ----
 ~> HDBSettings.sh landscapeHostConfiguration.py
-----
 
-The landscape host configuration is shown with a line per {saphana} host.
-
-[subs="specialchars,attributes"]
-----
 | Host   | Host   |... NameServer  | NameServer  | IndexServer | IndexServer
 |        | Active |... Config Role | Actual Role | Config Role | Actual Role
 | ------ | ------ |... ----------- | ----------- | ----------- | -----------
@@ -1136,21 +1066,13 @@ The landscape host configuration is shown with a line per {saphana} host.
 
 overall host status: ok
 ----
-==========
-+
-. Get an overview of instances of that site (as user {refsidadm})
-+
-.Get the list of instances
-=========
-[subs="specialchars,attributes"]
-----
-~> sapcontrol -nr {refinst} -function GetSystemInstanceList
-----
 
+Get an overview of instances of that site (as user {refsidadm})
 You should get a list of {saphana} instances belonging to that site.
 
 [subs="specialchars,attributes"]
 ----
+~> sapcontrol -nr {refinst} -function GetSystemInstanceList
 25.07.2022 17:25:16
 GetSystemInstanceList
 OK
@@ -1158,7 +1080,6 @@ hostname, instanceNr, httpPort, httpsPort, startPriority, features, dispstatus
 {hanaso0}, {inst}, 5{inst}13, 5{inst}14, 0.3, HDB|HDB_WORKER, GREEN
 {hanaso1}, {inst}, 5{inst}13, 5{inst}14, 0.3, HDB|HDB_WORKER, GREEN
 ----
-=========
 
 
 == Setting up {saphana} system replication
@@ -3057,6 +2978,53 @@ intention, this could trigger a takeover.
 |===
 
 
+[[cha.hanasr-example-systemv]]
+=== Example for checking legacy SystemV integration
+
+Check if the SAP hostagent is installed on all cluster nodes.
+As Linux user _root_, use the commands `systemctl` and `saphostctrl`
+to check the SAP hostagent:
+
+[subs="attributes,quotes"]
+----
+# systemctl status sapinit
+* sapinit.service - LSB: Start the sapstartsrv
+   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
+   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
+     Docs: man:systemd-sysv-generator(8)
+    Tasks: 0
+   CGroup: /system.slice/sapinit.service
+# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
+Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
+----
+The SystemV style sapinit is running and the hostagent recognises the installed
+database.
+
+As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
+overview of running {HANA} processes. The output of `HDB info` should
+be similar to the output shown below:
+
+[subs="attributes,quotes"]
+----
+{sapnode1}:{sapssid}adm> HDB info
+USER          PID     PPID  ... COMMAND
+{sapssid}adm      13017    ... -sh
+{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
+{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
+{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
+{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
+{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8756    ...      \_ hdbnameserver
+{sapssid}adm       9031    ...      \_ hdbcompileserver
+{sapssid}adm       9034    ...      \_ hdbpreprocessor
+{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
+{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
+{sapssid}adm       9531    ...      \_ hdbwebdispatcher
+{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
+----
+
+
 [[app.hana-sr.information]]
 == References
 
@@ -3102,16 +3070,17 @@ subs attribute accepts any of the following (in a list):
  Global Settings
 ////
 
-////
-// TODO PRIO3: revision history here ot at very top? see very top...
-// Revisions:
-// Revision 0.1 (2021-09-06) copied from 12 and replaced version strings, URLs, SAP notes, TIDs
-// Revision 0.2 (2022-03-08) prepared for systemd, established includes
-////
-
 ++++
 <?pdfpagebreak?>
 ++++
 
 include::common_gfdl1.2_i.adoc[]
 
+//
+// REVISION 0.1 (2021-09-06)
+//	- copied from 12 and replaced version strings, URLs, SAP notes, TIDs
+// REVISION 0.2 (2022-03-08)
+//	- prepared for systemd, established includes
+// REVISION 0.3 (2023-04-03)
+//	- SAP native systemd support is default for HANA 2.0 SPS07
+//

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-12.adoc
@@ -1,11 +1,3 @@
-// TODO PRIO1: Check if now the recommendation for the SAP HANA hook is clear and
-//             the explanation is well understandable
-// TODO PRIO1: Adding addendum for read-enabled
-// TODO PRIO1: Adding addendum for seamless maintenance
-// TODO PRIO1: Adding addendum for disk less SBD setup
-// TODO PRIO1: Cluster-init with more than one ring
-// DONE PRIO2: Issue#184 - Incorrect Expectation - Section 10.1.9 - centiqchris claims that expectation "WITHOUT quorum" is wrong
-//               I am quite sure this was WITHOUT in the past - first test have shown that SLES15SP? did show "with quorum" - lets double-check - also to be done in other guides!
 :docinfo:
 
 // Load document variables
@@ -21,20 +13,20 @@ include::Var_SLES4SAP-hana-sr-guide-PerfOpt-12-param.txt[]
 [[pre.hana-sr]]
 == About This Guide
 
+// TODO PRIO1: Check if now the recommendation for the SAP HANA hook is clear and the explanation is well understandable
+// TODO PRIO1: Adding addendum for read-enabled
+// TODO PRIO1: Adding addendum for seamless maintenance
+// TODO PRIO1: Adding addendum for disk less SBD setup
+// TODO PRIO1: Cluster-init with more than one ring
+//               I am quite sure this was WITHOUT in the past - first test have shown that SLES15SP? did show "with quorum" - lets double-check - also to be done in other guides!
 // TODO PRIO1: Review all lines with "TODO PRIOx:"
 // TODO PRIO1: Should we add a 3 nodes cluster variant with disk less fencing?
 // TODO PRIO1: Add information for active/active (read-enabled) to the document
-// DONE PRIO1: Adapt the document to include standard pages such as the document license
 // TODO PRIO1: Check all command examples + output, if they are still valid
-////
-DONE PRIO1: Describe SAP HANA HA/DR/SR provider hook and minimum package version
-TODO PRIO2: Scale-Up multi sid aka MCOS for the performance optimized scenario
-DONE PRIO1: Convert to use common include files from document team
-TODO PRIO1: Scale-Up with read-enabled (scheduled for 'next' publishing)
-TODO PRIO3: Scale-Up and Handshake takeover (scheduled for 'after next' publishing)
-TODO PRIO3: Scale-Up and multi target (scheduled for 'after next' publishing)
-TODO:
-////
+// TODO PRIO2: Scale-Up multi sid aka MCOS for the performance optimized scenario
+// TODO PRIO1: Scale-Up with read-enabled (scheduled for 'next' publishing)
+// TODO PRIO3: Scale-Up and Handshake takeover (scheduled for 'after next' publishing)
+// TODO PRIO3: Scale-Up and multi target (scheduled for 'after next' publishing)
 
 === Introduction
 
@@ -102,9 +94,9 @@ developed the scale-out resource agent package `{SAPHanaSR}-ScaleOut`.
 .{hana} System Replication Scale-Out in the Cluster
 image::SAPHanaSR-ScaleOut-Cluster.svg[scaledwidth=70.0%]
 
-With this mode of operation, internal {hana} high availability (HA)
+With this mode of operation, internal {HANA} high availability (HA)
 mechanisms and the resource agent must work together or be coordinated
-with each other. {hana} system replication automation for scale-out
+with each other. {HANA} system replication automation for scale-out
 is described in an own document available on our documentation Web page
 at {reslibrary}. The document for scale-out is named _"{docScaleOut}"_.
 
@@ -113,7 +105,7 @@ at {reslibrary}. The document for scale-out is named _"{docScaleOut}"_.
 {SUSE} has implemented the scale-up scenario with the `{SAPHanaRA}` resource
 agent (RA), which performs the actual check of the {HANA} database
 instances. This RA is configured as a master/slave resource. In the
-scale-up scenario, the master assumes responsibility for the {hana}
+scale-up scenario, the master assumes responsibility for the {HANA}
 databases running in primary mode. The slave is responsible for
 instances that are operated in synchronous (secondary) status.
 
@@ -595,10 +587,6 @@ Follow the instructions below on each node if you have installed the systems bas
 The pattern _High Availability_ summarizes all tools recommended to be installed on *all* nodes, including the
 _majority maker_.
 
-// DONE PRIO1: To install HA *and* SAPHanaSR now, because we need it during the setup of SAP HANA
-
-// To do so, for example, use zypper:
-
 .Installing additional software for the HA cluster
 ====
 . Install the `High Availability` pattern on all nodes
@@ -913,12 +901,12 @@ Bring the systems back to the original state:
 
 image::SAPHanaSR-ScaleOut-Plan-Phase5.svg[scaledwidth="100%"]
 
-// DONE: Feedback ps: explain better, when the python hook is needed.
-
-This step is mandatory to inform the cluster immediately if the secondary gets out of sync.
-The hook is called by {SAPHANA} using the HA/DR provider interface in point-of-time when the secondary gets out of
-sync. This is typically the case when the first commit pending is released. The hook is
-called by {SAPHANA} again when the system replication is back.
+This step is mandatory to inform the cluster immediately if the secondary gets
+out of sync.
+The hook is called by {SAPHANA} using the HA/DR provider interface in
+point-of-time when the secondary gets out of sync. This is typically the case
+when the first commit pending is released. The hook is called by {SAPHANA}
+again when the system replication is back.
 
 **Procedure**
 
@@ -1049,8 +1037,6 @@ Linux Enterprise High Availability Extension, which is part of the SUSE
 Linux Enterprise Server for SAP Applications, and {hana} Database
 Integration.
 
-// DONE PRIO1: Do we need to move that *before* we set-up the srHook?
-
 .Actions
 . Basic Cluster Configuration.
 
@@ -1089,13 +1075,13 @@ Determine the right watchdog module. Alternatively, you can find a list of
 installed drivers with your kernel version.
 
 ----
-ls -l /lib/modules/$(uname -r)/kernel/drivers/watchdog
+# ls -l /lib/modules/$(uname -r)/kernel/drivers/watchdog
 ----
 
 Check if any watchdog module is already loaded.
 
 ----
-lsmod | egrep "(wd|dog|i6|iT|ibm)"
+# lsmod | egrep "(wd|dog|i6|iT|ibm)"
 ----
 
 If you get a result, the system has already a loaded watchdog. If the watchdog
@@ -1105,8 +1091,8 @@ To safely unload the module, check first if an application is using the watchdog
 device.
 
 ----
-lsof /dev/watchdog
-rmmod <wrong_module>
+# lsof /dev/watchdog
+# rmmod <wrong_module>
 ----
 
 Enable your watchdog module and make it persistent. For the example below,
@@ -1114,15 +1100,15 @@ _softdog_ has been used which has some restrictions and should not be used as
 first option.
 
 ----
-echo softdog > /etc/modules-load.d/watchdog.conf
-systemctl restart systemd-modules-load
+# echo softdog > /etc/modules-load.d/watchdog.conf
+# systemctl restart systemd-modules-load
 ----
 
 Check if the watchdog module is loaded correctly.
 
 ----
-lsmod | grep dog
-ls -l /dev/watchdog
+# lsmod | grep dog
+# ls -l /dev/watchdog
 ----
 
 Testing the watchdog can be done with a simple action. Ensure to switch of your {sapHana}
@@ -1136,13 +1122,13 @@ resets/switches off the system. This is the intended mechanism. The following
 commands will force your system to be reset/switched off.
 
 ----
-touch /dev/watchdog
+# touch /dev/watchdog
 ----
 
 In case the softdog module is used the following action can be performed:
 
 ----
-echo 1> /dev/watchdog
+# echo 1> /dev/watchdog
 ----
 
 After your test was successful you must implement the watchdog on all cluster
@@ -1154,8 +1140,6 @@ members.
 
 For more information, see _Automatic Cluster Setup_, {uarr}SUSE Linux
 Enterprise High Availability Extension.
-
-// DONE PRIO1: Use the -u flag to already produce a valid unicast configuration at the first cluster configuration step
 
 Create an initial setup, using `{slehainit}` command and follow the
 dialogs. This has only to be done on the first cluster node.
@@ -2361,8 +2345,6 @@ different command line tools for cluster status requests.
 
 You can use an Internet browser to check the cluster status.
 
-// DONE PRIO1: We need a SLE12 HAWK screenshot here
-
 .Cluster Status in HAWK
 image::SAPHanaSR-ScaleUp-HAWK-Status-SLE12.png[scaledwidth=100%]
 
@@ -2551,9 +2533,6 @@ Prepare the cluster not to react on the maintenance work to be done on
 the SAP HANA database systems. Set the master/slave resource to be
 unmanaged and the cluster nodes in maintenance mode.
 
-
-// DONE PRIO1: Check, if command 'cleanup' is still valid (see discussion with E&I)
-//             'cleanup' replaced by 'refresh'
 
 .Main {hana} Update procedure
 ==============================
@@ -2816,6 +2795,54 @@ TID Addressing file system performance issues on NUMA machines::
 TID Overcommit Memory in SLES::
  https://www.suse.com/support/kb/doc.php?id=7002775
 
+TID Troubleshooting the SAPHanaSR python hook::
+ https://www.suse.com/support/kb/doc.php?id=000019865
+
+TID SAPHanaController running in timeout when starting SAP Hana::
+ https://www.suse.com/support/kb/doc.php?id=000019899
+
+TID SAP HANA monitors timed out after 5 seconds::
+ https://www.suse.com/support/kb/doc.php?id=000020626
+
+TID HA cluster takeover takes too long on HANA indexserver failure::
+ https://www.suse.com/support/kb/doc.php?id=000020845
+
+TID Cluster node fence as SAPHanaTopology fails ... during a normal cluster stop::
+ https://www.suse.com/support/kb/doc.php?id=000020964
+
+TID Basic health check for two-node SAP HANA performance based model::
+ https://www.suse.com/support/kb/doc.php?id=7022984
+
+TID HANA SystemReplication doesn't provide SiteName to Corosync Cluster::
+ https://www.suse.com/support/kb/doc.php?id=000019754
+
+TID SUSE Cluster Support for SAP HANA System Replication Active / Active ...::
+ https://www.suse.com/support/kb/doc.php?id=7023884
+
+TID SAPHanaSR-showAttr fails with error "Error: NIECONN_REFUSED ..."::
+ https://www.suse.com/support/kb/doc.php?id=000020548
+
+TID The vIP cluster resource does not follow the SAP HANA master ...::
+ https://www.suse.com/support/kb/doc.php?id=000019769
+
+TID HANA fail-over ... fail due to excessive os.system() execution times::
+ https://www.suse.com/support/kb/doc.php?id=000020835
+
+TID Address space monitoring and HANA DB performance::
+ https://www.suse.com/support/kb/doc.php?id=000020746
+
+TID HANA nodes end up having the same LPT values::
+ https://www.suse.com/support/kb/doc.php?id=000020690
+
+TID XFS metadata corruption and invalid checksum on SAP Hana servers::
+ https://www.suse.com/support/kb/doc.php?id=7022921
+
+TID Handling failed NFS share in SUSE HA cluster for HANA system replication::
+ https://www.suse.com/support/kb/doc.php?id=000019904
+
+TID Indepth HANA Cluster Debug Data Collection (PACEMAKER, SAP)::
+ https://www.suse.com/support/kb/doc.php?id=7022702
+
 {slsa} technical information::
  https://www.suse.com/products/server/technical-information/
 
@@ -2824,12 +2851,26 @@ XFS file system::
 
 === Manual Pages
 
+corosync.conf::
+ corosync.conf.5
 crm::
  crm.8
+crm_mon::
+ crm_mon.8
 crm_simulate::
  crm_simulate.8
 cs_clusterstate::
  cs_clusterstate.8
+cs_show_sbd_devices::
+ cs_show_sbd_devices.8
+cs_wait_for_idle::
+ cs_wait_for_idle.8
+ha_related_sap_notes::
+ ha_related_sap_notes.7
+ha_related_suse_tids::
+ ha_related_suse_tids.7
+ocf_heartbeat_IPaddr2::
+ ocf_heartbeat_IPaddr2.7
 ocf_suse_SAPHana::
  ocf_suse_SAPHana.7
 ocf_suse_SAPHanaTopology::
@@ -2838,14 +2879,28 @@ sbd::
  sbd.8
 stonith_sbd::
  stonith_sbd.7
+susChkSrv.py::
+ susChkSrv.py.7
+susTkOver.py::
+ susTkOver.py.7
 SAPHanaSR::
  SAPHanaSR.7
+SAPHanaSR.py::
+ SAPHanaSR.py.7
+SAPHanaSR-manageProvider::
+ SAPHanaSR-manageProvider.8
+SAPHanaSR-filter::
+ SAPHanaSR-filter.8
 SAPHanaSR-showAttr::
  SAPHanaSR-showAttr.8
 SAPHanaSR-replay-archive::
  SAPHanaSR-replay-archive.8
+SAPHanaSR_basic_cluster::
+ SAPHanaSR_basic_cluster.7
 SAPHanaSR_manitenance_examples::
- SAPHanaSR_manitenance_examples.8
+ SAPHanaSR_maintenance_examples.7
+votequorum::
+ votequorum.5
 
 === SAP Product Documentation
 
@@ -3050,9 +3105,6 @@ nodelist {
 }
 
 quorum {
-
-        # Enable and configure quorum subsystem (default: off)
-        # see also corosync.conf.5 and votequorum.5
         provider: corosync_votequorum
         expected_votes: 2
         two_node: 1
@@ -3085,17 +3137,15 @@ Pacemaker Project Documentation::
 https://clusterlabs.org/pacemaker/doc/
 
 :leveloffset: 2
-
 // TODO PRIO2: Moving SAP NOTE references to external file _SAPNotes_SAPHANA20.adoc_
 //include::SAPNotes_SAPHANA20.adoc[]
-
+:leveloffset: 0
 
 ++++
 <?pdfpagebreak?>
 ++++
 
-:leveloffset: 0
-// Standard SUSE Best Practices includes
+
 == Legal notice
 include::common_sbp_legal_notice.adoc[]
 
@@ -3104,7 +3154,6 @@ include::common_sbp_legal_notice.adoc[]
 ++++
 
 // Standard SUSE Best Practices includes
-:leveloffset: 0
 include::common_gfdl1.2_i.adoc[]
 
 //
@@ -3127,3 +3176,6 @@ include::common_gfdl1.2_i.adoc[]
 //   - backport fix on smaller typos and style check from SLE15 doc review
 // REVISION 1.3.2 2022/12
 //   - details on srHook and sudoers
+// REVISION 1.3.3 2023/04
+//  - TIDs and manual pages
+//

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -3527,7 +3527,7 @@ include::common_gfdl1.2_i.adoc[]
 // REVISION 1.6 2022/08
 //   - susChkSrv.py
 //   - updated examples, reference
-// REVISION 1.i6a 2023/04
+// REVISION 1.6a 2023/04
 //   - SAP native systemd support is default for HANA 2.0 SPS07
 //
 

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -198,6 +198,7 @@ The setup and configuration from a cluster point of view is the same for multi-t
 Thus you can use the above documents for both kinds of scenarios.
 
 // TODO PRIO1: Add new restrictions here (think about multi-target, handshake, ...)
+// TODO PRIO1: add link to overview on supported scenarios
 
 ==== The concept of the performance optimized scenario
 
@@ -351,13 +352,6 @@ are using strong separation of the tenants.
 As an example, killing the complete {HANA} instance using _HDB kill_ does not work,
 because the tenants are running with different Linux user UIDs.
 _{refsidadm}_ is not allowed to terminate the processes of the other tenant users.
-////
-// TODO PRIO1: remove HANA 1.0?
-// ** For {HANA} 1.0 you need version SPS10 rev3, SPS11 or newer if you want to stop
-// tenants during production and you want the cluster to be able to take over.
-// Older {HANA} versions are marking the system replication as failed if
-// you stop a tenant.
-////
 * Only one system replication between the two {HANA} database in the Linux
 cluster.  Maximum one system replication to an {HANA} database outside the Linux
 cluster.
@@ -376,23 +370,20 @@ beginning with {HANA} version 1.0 SPS 7 patch level 70, recommended is SPS 11. W
 in {HANA} multi-target environments, the current resource agent manages only two sites.
 Thus only two {HANA} sites are part of the Linux cluster.
 * Besides {HANA} you need {SAP} hostagent installed and started on your system.
-For SystemV style, the sapinit script needs to be active.
-////
-// TODO PRIO1: publish the below, once SAP ships systemd integration for {HANA}
-// For systemd style, the
-// services saphostagent and SAP<SID>_<INO> can stay enabled. The systemd enabled
-// saphostagent and instance´s sapstartsrv is supported from SAPHanaSR 0.155 onwards.
-// Refer to the OS documentation for the systemd version. Refer to {SAP}
-// documentation for the {HANA} version. Combining systemd style hostagent with
-// SystemV style instance is allowed. However, all nodes in one Linux cluster need to
-// use the same style.
-////
+** For SystemV style, the sapinit script needs to be active.
+** For systemd style, the service SAP<SID>_<INO> can stay enabled.
+The systemd enabled saphostagent and instance´s sapstartsrv is supported from SAPHanaSR
+0.155 onwards. Refer to the OS documentation for the systemd version.
+{HANA} comes with native systemd integration as default starting with version 2.0 SPS07.
+Refer to {SAP} documentation for information on other {HANA} versions.
+** Combining systemd style hostagent with SystemV style instance is allowed.
+However, all nodes in one Linux cluster need to use the same style.
 * The RA's monitoring operations need to be active.
 * Using HA/DR provider hook for srConnectionChanged() by enabling SAPHanaSR.py is
 strongly  recommended for all scenarios. This might become mandatory in future versions.
 ** Using SAPHanaSR.py is yet already mandatory for multi-tier and multi-target replication.
 ** The Linux cluster needs to be up and running to allow HA/DR provider events being
-written into CIB attributes. The current HANA SR status might differ from CIB srHook
+written into CIB attributes. The current {HANA} SR status might differ from CIB srHook
 attribute after cluster maintenance.
 // TODO PRIO2: update above sentence, once we ship pick-up e.g. 0.155
 * RA and srHook runtime almost completely depends on call-outs to controlled
@@ -410,13 +401,6 @@ Linux cluster.
 memory can be used, as long as they are transparent to Linux HA.
 
 // TODO PRIO3: align with manual pages SAPHanaSR(7) and SAPHanaSR.py(7)
-// TODO PRIO2: remove HANA 1.0?
-////
-You need at least {SAPHanaSR} version {sapHanaSrMinVers} and in best {sles4sap} {prodnr}
-{prodsp} or newer. {HANA} 1.0 is supported since SPS09 (095) for all mentioned setups.
-{HANA} 2.0 is supported with all known SPS versions.
-////
-
 For the HA/DR provider hook scripts SAPHanaSR.py and susTkOver.py, the following
 requirements apply:
 
@@ -707,6 +691,7 @@ simplifies common administrative tasks.
 For more information, see section _Installation and Basic Setup_ of the {uarr}
 {sleha} guide.
 
+
 [[cha.s4s.hana-install]]
 == {stepHANA}
 
@@ -716,6 +701,10 @@ Even though this document focuses on the integration of an installed {HANA} with
 system replication already set up into the Linux cluster, this chapter summarizes
 the test environment. Always use the official documentation from {SAP} to install
 {HANA} and to set up the system replication.
+
+This guide shows {HANA} and saphostagent with native systemd integration. 
+An example for legacy SystemV is outlined in the appendix
+<<cha.hanasr-example-systemd>>.
 
 .Procedure
 
@@ -735,9 +724,6 @@ If this SAP service is not installed, install it now.
 * Install the {HANA} database as described in the {HANA} Server Installation Guide.
 The {HANA} database client will be installed together with the server by default.
 
-// TODO PRIO1: publish the below, once SAP ships systemd integration for HANA
-// begin systemd style
-////
 === Checking if the SAP hostagent is installed on all cluster nodes
 
 Check if the native `systemd`-enabled SAP hostagent and instance `sapstartsrv`
@@ -790,62 +776,7 @@ Unit SAP.slice (/SAP.slice):
 The SAP hostagent `saphostagent.service` and the instance´s `sapstartsrv` `SAP{sapsid}_{sapino}.service`
 are running in the `SAP.slice`.
 See also manual pages systemctl(8) and systemd-cgls(8) for details.
-////
-// end systemd style
 
-// TODO PRIO1: remove below, once SAP ships systemd integration for HANA
-// begin systemV style
-// ////
-=== Checking if the SAP hostagent is installed on all cluster nodes
-
-Check if the SAP hostagent is installed on all cluster nodes.
-If not, install and enable it now.
-
-As Linux user _root_, use the commands `systemctl` and `saphostctrl`
-to check the SAP hostagent:
-
-[subs="attributes,quotes"]
-----
-# systemctl status sapinit
-* sapinit.service - LSB: Start the sapstartsrv
-   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
-   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
-     Docs: man:systemd-sysv-generator(8)
-    Tasks: 0
-   CGroup: /system.slice/sapinit.service
-# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
-Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
-----
-The SystemV style sapinit is running and the hostagent recognises the installed
-database.
-
-=== Verify that both databases are up and running
-
-As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
-overview of running {HANA} processes. The output of `HDB info` should
-be similar to the output shown below:
-
-[subs="attributes,quotes"]
-----
-{sapnode1}:{sapssid}adm> HDB info
-USER          PID     PPID  ... COMMAND
-{sapssid}adm      13017    ... -sh
-{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
-{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
-{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
-{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
-{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8756    ...      \_ hdbnameserver
-{sapssid}adm       9031    ...      \_ hdbcompileserver
-{sapssid}adm       9034    ...      \_ hdbpreprocessor
-{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
-{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
-{sapssid}adm       9531    ...      \_ hdbwebdispatcher
-{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
-----
-// ////
-// end systemV style
 
 [[cha.s4s.hana-sys-replication]]
 == {stepHSR}
@@ -3489,6 +3420,52 @@ location loc_{sapnode1}_stonith rsc_{sapnode1}_stonith -inf: {sapnode1}
 location loc_{sapnode2}_stonith rsc_{sapnode2}_stonith -inf: {sapnode2}
 ----
 
+[[cha.hanasr-example-systemd]]
+=== Example for checking legacy SystemV integration
+
+Check if the SAP hostagent is installed on all cluster nodes.
+As Linux user _root_, use the commands `systemctl` and `saphostctrl`
+to check the SAP hostagent:
+
+[subs="attributes,quotes"]
+----
+# systemctl status sapinit
+* sapinit.service - LSB: Start the sapstartsrv
+   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
+   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
+     Docs: man:systemd-sysv-generator(8)
+    Tasks: 0
+   CGroup: /system.slice/sapinit.service
+# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
+Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
+----
+The SystemV style sapinit is running and the hostagent recognises the installed
+database.
+
+As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
+overview of running {HANA} processes. The output of `HDB info` should
+be similar to the output shown below:
+
+[subs="attributes,quotes"]
+----
+{sapnode1}:{sapssid}adm> HDB info
+USER          PID     PPID  ... COMMAND
+{sapssid}adm      13017    ... -sh
+{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
+{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
+{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
+{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
+{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8756    ...      \_ hdbnameserver
+{sapssid}adm       9031    ...      \_ hdbcompileserver
+{sapssid}adm       9034    ...      \_ hdbpreprocessor
+{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
+{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
+{sapssid}adm       9531    ...      \_ hdbwebdispatcher
+{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
+----
+
 
 [[app.hana-sr.information]]
 == References
@@ -3550,5 +3527,7 @@ include::common_gfdl1.2_i.adoc[]
 // REVISION 1.6 2022/08
 //   - susChkSrv.py
 //   - updated examples, reference
+// REVISION 1.i6a 2023/04
+//   - SAP native systemd support is default for HANA 2.0 SPS07
 //
 

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -704,7 +704,7 @@ the test environment. Always use the official documentation from {SAP} to instal
 
 This guide shows {HANA} and saphostagent with native systemd integration. 
 An example for legacy SystemV is outlined in the appendix
-<<cha.hanasr-example-systemd>>.
+<<cha.hanasr-example-systemv>>.
 
 .Procedure
 
@@ -3420,7 +3420,7 @@ location loc_{sapnode1}_stonith rsc_{sapnode1}_stonith -inf: {sapnode1}
 location loc_{sapnode2}_stonith rsc_{sapnode2}_stonith -inf: {sapnode2}
 ----
 
-[[cha.hanasr-example-systemd]]
+[[cha.hanasr-example-systemv]]
 === Example for checking legacy SystemV integration
 
 Check if the SAP hostagent is installed on all cluster nodes.

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -1,9 +1,3 @@
-// TODO PRIO1: Check if now the recommendation for the SAP HANA hook is clear and
-//             the explanation is well understandable
-// TODO PRIO1: Adding addendum for read-enabled
-// TODO PRIO1: Adding addendum for seamless maintenance
-// TODO PRIO1: Adding addendum for disk less SBD setup
-// TODO PRIO1: Cluster-init with more than one ring
 :docinfo:
 
 // Load document variables
@@ -26,6 +20,12 @@ include::Var_SLES4SAP-hana-sr-guide-PerfOpt-15-param.txt[]
 // TODO PRIO1: Scale-Up with read-enabled (scheduled for 'next' publishing)
 // TODO PRIO3: Scale-Up and Handshake takeover (scheduled for 'after next' publishing)
 // TODO PRIO3: Scale-Up and multi-target (scheduled for 'after next' publishing)
+// TODO PRIO1: Check if now the recommendation for the SAP HANA hook is clear and
+//             the explanation is well understandable
+// TODO PRIO1: Adding addendum for read-enabled
+// TODO PRIO1: Adding addendum for seamless maintenance
+// TODO PRIO1: Adding addendum for disk less SBD setup
+// TODO PRIO1: Cluster-init with more than one ring
 
 ////
    ____      __                 __           __  _

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -3319,6 +3319,7 @@ op_defaults op-options \
 The following file shows a typical corosync configuration with two rings.
 Review the SUSE product documentation about details.
 See also manual pages corosync.conf(5) and votequorum(5).
+// TODO PRIO3: get corosync.conf from common include file
 
 [subs="attributes,quotes"]
 ----
@@ -3377,9 +3378,6 @@ nodelist {
 }
 
 quorum {
-
-        # Enable and configure quorum subsystem (default: off)
-        # see also corosync.conf.5 and votequorum.5
         provider: corosync_votequorum
         expected_votes: 2
         two_node: 1
@@ -3423,48 +3421,11 @@ location loc_{sapnode2}_stonith rsc_{sapnode2}_stonith -inf: {sapnode2}
 [[cha.hanasr-example-systemv]]
 === Example for checking legacy SystemV integration
 
-Check if the SAP hostagent is installed on all cluster nodes.
-As Linux user _root_, use the commands `systemctl` and `saphostctrl`
-to check the SAP hostagent:
+include::SLES4SAP-hana-systemv-appendix.adoc[]
 
-[subs="attributes,quotes"]
-----
-# systemctl status sapinit
-* sapinit.service - LSB: Start the sapstartsrv
-   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
-   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
-     Docs: man:systemd-sysv-generator(8)
-    Tasks: 0
-   CGroup: /system.slice/sapinit.service
-# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
-Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
-----
-The SystemV style sapinit is running and the hostagent recognises the installed
-database.
-
-As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
-overview of running {HANA} processes. The output of `HDB info` should
-be similar to the output shown below:
-
-[subs="attributes,quotes"]
-----
-{sapnode1}:{sapssid}adm> HDB info
-USER          PID     PPID  ... COMMAND
-{sapssid}adm      13017    ... -sh
-{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
-{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
-{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
-{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
-{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8756    ...      \_ hdbnameserver
-{sapssid}adm       9031    ...      \_ hdbcompileserver
-{sapssid}adm       9034    ...      \_ hdbpreprocessor
-{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
-{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
-{sapssid}adm       9531    ...      \_ hdbwebdispatcher
-{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
-----
+++++
+<?pdfpagebreak?>
+++++
 
 
 [[app.hana-sr.information]]
@@ -3475,19 +3436,18 @@ For more detailed information, have a look at the documents listed below.
 // SUSE docu, manual pages, TIDs and blogs. SAP guides and notes.
 :leveloffset: 2
 include::SAPNotes_HANA20_15.adoc[]
-
 :leveloffset: 0
+
 === Pacemaker
 
 Pacemaker Project Documentation::
  https://clusterlabs.org/pacemaker/doc/
 
-
 ++++
 <?pdfpagebreak?>
 ++++
 
-:leveloffset: 0
+
 // Standard SUSE Best Practices includes
 == Legal notice
 include::common_sbp_legal_notice.adoc[]
@@ -3497,7 +3457,6 @@ include::common_sbp_legal_notice.adoc[]
 ++++
 
 // Standard SUSE Best Practices includes
-:leveloffset: 0
 include::common_gfdl1.2_i.adoc[]
 
 //

--- a/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
@@ -3584,8 +3584,8 @@ For more detailed information, have a look at the documents listed below.
 // SUSE docu, manual pages, TIDs and blogs. SAP guides and notes.
 :leveloffset: 2
 include::SAPNotes_HANA20_15.adoc[]
-
 :leveloffset: 0
+
 === Pacemaker
 
 Pacemaker Project Documentation::
@@ -3731,6 +3731,7 @@ op_defaults op-options \
 The following file shows a typical corosync configuration with two rings.
 Review the SUSE product documentation about details.
 See also manual pages corosync.conf(5) and votequorum(5).
+// TODO PRIO3: get corosync.conf from common include file
 
 [subs="attributes,quotes"]
 ----
@@ -3789,9 +3790,6 @@ nodelist {
 }
 
 quorum {
-
-        # Enable and configure quorum subsystem (default: off)
-        # see also corosync.conf.5 and votequorum.5
         provider: corosync_votequorum
         expected_votes: 2
         two_node: 1
@@ -3836,48 +3834,7 @@ location loc_{sapnode2}_stonith rsc_{sapnode2}_stonith -inf: {sapnode2}
 [[cha.hanasr-example-systemv]]
 === Example for checking legacy SystemV integration
 
-Check if the SAP hostagent is installed on all cluster nodes.
-As Linux user _root_, use the commands `systemctl` and `saphostctrl`
-to check the SAP hostagent:
-
-[subs="attributes,quotes"]
-----
-# systemctl status sapinit
-* sapinit.service - LSB: Start the sapstartsrv
-   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
-   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
-     Docs: man:systemd-sysv-generator(8)
-    Tasks: 0
-   CGroup: /system.slice/sapinit.service
-# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
-Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
-----
-The SystemV style sapinit is running and the hostagent recognises the installed
-database.
-
-As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
-overview of running {HANA} processes. The output of `HDB info` should
-be similar to the output shown below:
-
-[subs="attributes,quotes"]
-----
-{sapnode1}:{sapssid}adm> HDB info
-USER          PID     PPID  ... COMMAND
-{sapssid}adm      13017    ... -sh
-{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
-{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
-{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
-{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
-{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
-{sapssid}adm       8756    ...      \_ hdbnameserver
-{sapssid}adm       9031    ...      \_ hdbcompileserver
-{sapssid}adm       9034    ...      \_ hdbpreprocessor
-{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
-{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
-{sapssid}adm       9531    ...      \_ hdbwebdispatcher
-{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
-----
+include::SLES4SAP-hana-systemv-appendix.adoc[]
 
 === {haDrCostOptMem}
 

--- a/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
@@ -306,7 +306,7 @@ will be updated, maintained and published at a higher frequency:
 (https://www.suse.com/support/kb/doc/?id=7023526 -
 see also the blog article https://www.suse.com/c/lets-flip-the-flags-is-my-sap-hana-database-in-sync-or-not/)
 
-// TODO PRIO3: TID  errata for CostOpt insteaf ogf below
+// TODO PRIO3: TID  errata for CostOpt instead of below
 // In addition to this guide, check the SUSE SAP Best Practice Guide Errata for other solutions
 // (https://www.suse.com/support/kb/doc/?id=7023713).
 
@@ -391,18 +391,6 @@ The {SLES4SAP} versions are:
 * Intel Optane DCPMM (aka PMEM) is supported since {sles4sap} {prodNr} GA or newer.
 * IBM Power vPMEM is supported since {SLES4SAP} {prodNr} SP1 or newer.
 
-////
-* {HANA} versions:
-// TODO PRIO3: remove HANA 1.0
-** {HANA} 1.0 is supported since SPS09 (095) for all mentioned setups. {HANA} 1.0
-does not support the HA/DR provider hook method srConnectionChanged() with
-multi-target aware parameters. These parameters are needed for the HA/DR provider
-hook in the package.
-** For {HANA} 1.0 you need version SPS10 rev3, SPS11 or newer if you want to stop
-tenants during production and you want the cluster to be able to take over. Older
-{HANA} versions are marking the system replication as failed if you stop a tenant.
-////
-
 For the HA/DR provider hook scripts SAPHanaSR.py and susCostOpt.py, the following
 requirements apply:
 
@@ -421,6 +409,12 @@ Additional considerations for the {HANA} version are:
 from {HANA}'s persistent memory features. Local restart and takeover are affected
 by the time {HANA} needs for shutdown and loading column store. {HANA} 2.0 SPS04 and
 later support persistent memory.
+* Starting with {HANA} 2.0 SPS07, systemd native integration is default.
+* Besides {HANA} you need {SAP} hostagent installed and started on your system.
+** For SystemV style, the sapinit script needs to be active.
+** For systemd style SAPHanaSR, the service SAP<SID>_<INO> can stay enabled.
+** The systemd enabled saphostagent and instance´s sapstartsrv is supported from SAPHanaSR
+0.155 and resource-agents 4.4.0 onwards.
 
 IMPORTANT: Without a valid STONITH method, the complete cluster is unsupported
 and will not work properly.
@@ -429,8 +423,6 @@ If you need to implement a different scenario, we strongly recommend to define
 a Proof of Concept (PoC) with {suse}. This PoC will focus on testing the existing
 solution in your scenario. Most of the above mentioned limitations are set
 because careful testing is needed.
-
-In addition to {HANA}, you need to install the {SAP} Host Agent on your system.
 
 For information on supported hardware and virtualization, refer to the {SUSE}
 release notes and hardware compatibility database:
@@ -724,6 +716,10 @@ system replication already set up into the Linux cluster, this chapter summarize
 the test environment. Always use the official documentation from {sap} to install
 {HANA} and to set up the system replication.
 
+This guide shows {HANA} and saphostagent with native systemd integration.
+An example for legacy SystemV is outlined in the appendix
+<<cha.hanasr-example-systemv>>.
+
 .Procedure
 
 . Install the replicating {HANA} databases.
@@ -746,9 +742,7 @@ If this SAP service is not installed, install it now.
 * Install the {HANA} database as described in the {HANA} Server Installation Guide.
 The {HANA} database client will be installed together with the server by default.
 
-// TODO PRIO1: publish the below, once SAP ships systemd integration for HANA
 // begin systemd style
-////
 === Check if the SAP hostagent is installed on all cluster nodes
 
 Check if the native `systemd`-enabled SAP hostagent and instance `sapstartsrv`
@@ -802,12 +796,10 @@ Unit SAP.slice (/SAP.slice):
 The SAP hostagent `saphostagent.service` and the instance´s `sapstartsrv` `SAP{sapsid}_{sapino}.service`
 are running in the `SAP.slice`. The example above is taken from the primary node.
 See also manual pages systemctl(8) and systemd-cgls(8) for details.
-////
 // end systemd style
 
-// TODO PRIO1: remove below, once SAP ships systemd integration for HANA
 // begin systemV style
-// ////
+////
 === Check if the SAP hostagent is installed on all cluster nodes
 
 Check if the SAP hostagent is installed on all cluster nodes.
@@ -856,7 +848,7 @@ USER          PID     PPID  ... COMMAND
 {sapssid}adm       9531    ...      \_ hdbwebdispatcher
 {sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
 ----
-// ////
+////
 // end systemV style
 
 === Install the non-replicated {HANA} on the secondary site
@@ -879,9 +871,7 @@ global_allocation_limit = <size_in_mb_for_non_replicated_hana>
 ----
 =========
 
-// TODO PRIO1: publish the below, once SAP ships systemd integration for HANA
 // begin systemd style
-////
 .Verify that the non-replicating database is up and running.
 
 [subs="attributes,quotes"]
@@ -917,7 +907,6 @@ The SAP hostagent `saphostagent.service` and the non-replicating instance´s sap
 `SAP{sapnpsid}_{sapnpino}.service` are running in the `SAP.slice`. If the replicating
 and non-replicating instances are both running, both will show up.
 See also manual pages systemctl(8) and systemd-cgls(8) for details.
-////
 // end systemd style
 
 
@@ -1251,8 +1240,8 @@ Stop {HANA} either with _HDB_ or using _sapcontrol_.
 
 .Adding SAPHanaSR via global.ini
 ==========
-Use the {HANA} tools for changing global.ini.
-// TODO PRIO2: use official HANA python tool for changing global.ini
+Use the {HANA} tools for changing global.ini. See also manual page
+SAPHanaSR-manageProvider(8).
 
 ----
 [ha_dr_provider_saphanasr]
@@ -3844,7 +3833,53 @@ location loc_{sapnode1}_stonith rsc_{sapnode1}_stonith -inf: {sapnode1}
 location loc_{sapnode2}_stonith rsc_{sapnode2}_stonith -inf: {sapnode2}
 ----
 
-==== {haDrCostOptMem}
+[[cha.hanasr-example-systemv]]
+=== Example for checking legacy SystemV integration
+
+Check if the SAP hostagent is installed on all cluster nodes.
+As Linux user _root_, use the commands `systemctl` and `saphostctrl`
+to check the SAP hostagent:
+
+[subs="attributes,quotes"]
+----
+# systemctl status sapinit
+* sapinit.service - LSB: Start the sapstartsrv
+   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
+   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
+     Docs: man:systemd-sysv-generator(8)
+    Tasks: 0
+   CGroup: /system.slice/sapinit.service
+# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
+Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
+----
+The SystemV style sapinit is running and the hostagent recognises the installed
+database.
+
+As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
+overview of running {HANA} processes. The output of `HDB info` should
+be similar to the output shown below:
+
+[subs="attributes,quotes"]
+----
+{sapnode1}:{sapssid}adm> HDB info
+USER          PID     PPID  ... COMMAND
+{sapssid}adm      13017    ... -sh
+{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
+{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
+{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
+{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
+{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8756    ...      \_ hdbnameserver
+{sapssid}adm       9031    ...      \_ hdbcompileserver
+{sapssid}adm       9034    ...      \_ hdbpreprocessor
+{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
+{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
+{sapssid}adm       9531    ...      \_ hdbwebdispatcher
+{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
+----
+
+=== {haDrCostOptMem}
 
 NOTE: This hook script must not be used for new installations. It is listed here
 to document former setups.
@@ -3970,4 +4005,6 @@ include::common_gfdl1.2_i.adoc[]
 //   - more priority fencing
 // REVISION 1.5 2022/06
 //   - susCostOpt.py from SAPHanaSR replaced custom script {haDrCostOptMem}
+// REVISION 1.6 2023/04
+//   - SAP native systemd support is default for HANA 2.0 SPS07
 //

--- a/adoc/SLES4SAP-hana-systemv-appendix.adoc
+++ b/adoc/SLES4SAP-hana-systemv-appendix.adoc
@@ -1,0 +1,43 @@
+Check if the SAP hostagent is installed on all cluster nodes.
+As Linux user _root_, use the commands `systemctl` and `saphostctrl`
+to check the SAP hostagent:
+
+[subs="attributes,quotes"]
+----
+# systemctl status sapinit
+* sapinit.service - LSB: Start the sapstartsrv
+   Loaded: loaded (/etc/init.d/sapinit; generated; vendor preset: disabled)
+   Active: active (exited) since Wed 2022-02-09 17:25:36 CET; 3 weeks 0 days ago
+     Docs: man:systemd-sysv-generator(8)
+    Tasks: 0
+   CGroup: /system.slice/sapinit.service
+# /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
+Inst Info : {sapsid} - {sapino} - {sapnode1} - 753, patch 819, changelist 2069355
+----
+The SystemV style sapinit is running and the hostagent recognises the installed
+database.
+
+As Linux user _{refsidadm}_, use the command line tool `HDB` to get an
+overview of running {HANA} processes. The output of `HDB info` should
+be similar to the output shown below:
+
+[subs="attributes,quotes"]
+----
+{sapnode1}:{sapssid}adm> HDB info
+USER          PID     PPID  ... COMMAND
+{sapssid}adm      13017    ... -sh
+{sapssid}adm      13072    ...  \_ /bin/sh /usr/sap/{sapsid}/HDB{sapino}/HDB info
+{sapssid}adm      13103    ...      \_ ps fx -U {sapssid}adm -o user:8,pid:8,ppid:8,pcpu:5,vsz:10,rss:10,args
+{sapssid}adm       9268    ... hdbrsutil  --start --port 3{sapino}03 --volume 2 --volumesuffix mnt00001/hdb00002.00003 --identifier 1580897137
+{sapssid}adm       8911    ... hdbrsutil  --start --port 3{sapino}01 --volume 1 --volumesuffix mnt00001/hdb00001 --identifier 1580897100
+{sapssid}adm       8729    ... sapstart pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8738    ...  \_ /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/trace/hdb.sap{sapsid}_HDB{sapino} -d -nw -f /usr/sap/{sapsid}/HDB{sapino}/{sapnode1}/daemon.ini pf=/usr/sap/{sapsid}/SYS/profile/{sapsid}_HDB{sapino}_{sapnode1}
+{sapssid}adm       8756    ...      \_ hdbnameserver
+{sapssid}adm       9031    ...      \_ hdbcompileserver
+{sapssid}adm       9034    ...      \_ hdbpreprocessor
+{sapssid}adm       9081    ...      \_ hdbindexserver -port 3{sapino}03
+{sapssid}adm       9084    ...      \_ hdbxsengine -port 3{sapino}07
+{sapssid}adm       9531    ...      \_ hdbwebdispatcher
+{sapssid}adm       8574    ... /usr/sap/{sapsid}/HDB{sapino}/exe/sapstartsrv pf=/hana/shared/{sapsid}/profile/{sapsid}_HDB{sapino}_{sapnode1} -D -u {sapssid}adm
+----
+

--- a/adoc/Variables_HA740.adoc
+++ b/adoc/Variables_HA740.adoc
@@ -43,7 +43,7 @@
 :myNFSSrv: nfs1
 :myNFSExpPath: /data/nfs/suseEnqReplNW740
 :myNFSSapmnt: /sapmnt
-:myNFSUsrSap: /usr/sap/{mySid}
+:myNFSUsrSap: /usr/sap
 :myNFSSys:    {myNFSUsrSap}/SYS
 :myNFSExpPathSapMedia740: /data/SCT/media/SAP-MEDIA/NW74
 :myNFSExpPathSapMedia750: /data/SCT/media/SAP-MEDIA/NW75
@@ -88,7 +88,6 @@
 :sapHostAgent: saphostagent
 
 :linux: Linux
-
 
 :suse: SUSE
 :SUSEReg: SUSE(R)

--- a/adoc/Variables_HA740.adoc
+++ b/adoc/Variables_HA740.adoc
@@ -43,7 +43,8 @@
 :myNFSSrv: nfs1
 :myNFSExpPath: /data/nfs/suseEnqReplNW740
 :myNFSSapmnt: /sapmnt
-:myNFSSys:   /usr/sap/{mySid}/SYS
+:myNFSUsrSap: /usr/sap/{mySid}
+:myNFSSys:    {myNFSUsrSap}/SYS
 :myNFSExpPathSapMedia740: /data/SCT/media/SAP-MEDIA/NW74
 :myNFSExpPathSapMedia750: /data/SCT/media/SAP-MEDIA/NW75
 :myNFSSapmedia: /sapcd
@@ -53,7 +54,7 @@
 :myVipNDb:   sapha1db
 :bsVipNDb:   sapnwcdb
 :myVipNPas:  sapha1d1
-:myVipNDSec:   sapha1d2
+:myVipNDSec: sapha1d2
 
 :myNode1: hacert01
 :myNode2: hacert02

--- a/adoc/sap-nw740-sle15-setupguide.adoc
+++ b/adoc/sap-nw740-sle15-setupguide.adoc
@@ -1692,11 +1692,59 @@ op_defaults op-options: \
 	record-pending=true
 ----
 
-=== CRM configuration fragments of the two-node cluster with simple mount setup
+=== Example for the two-node cluster with simple-mount setup
+
+In contrast to the traditional setups, this setup uses an additional NFS mount
+for the {sap} application layer without the need to have dedicated block devices
+and cluster-controlled file systems. That greatly simplifies the overall
+architecture, implementation and maintenance of a {sleHA} cluster for {sapNW}
+with {sapERS}.
+See also SUSE TID https://www.suse.com/support/kb/doc/?id=000019944.
+
+==== systemd services for simple-mount setup
+
+Disable *systemd* services of the ASCS and the ERS {sap} instance:
+
+[subs="specialchars,attributes"]
+----
+# systemctl disable SAP{mySid}_{myAscsIno}.service
+# systemctl disable SAP{mySid}_{myErsIno}.service
+----
+
+With the `sapstartsrv-resource-agents` RPM package there come two *systemd*
+services called `sapping` and `sappong`. `sapping` runs before `sapinit` and
+moves _/usr/sap/sapservices_ out of the way. `sappong` runs after `sapinit`
+and moves _/usr/sap/sapservices_ back to its original location.
+
+[subs="attributes"]
+----
+# zypper info sapstartsrv-resource-agents
+# systemctl enable sapping
+# systemctl enable sappong
+----
+See manual pages ocf_suse_SAPStartSrv(7), sapping(8) and SAPStartSrv_basic_cluster(7)
+for details.
+
+==== fstab entries for simple-mount setup
+
+As the directories _/sapmnt/{mySid}_, _/usr/sap/{mySid}_ need to be available
+at all time, make sure they are mounted during boot. This can be
+achieved by putting the information into the _/etc/fstab_.
+Mount options may depend on your particular environment.
+
+[subs="specialchars,attributes"]
+----
+{myNfsSrv}:{myNFSSapmnt}/{mySid} /sapmnt/{mySid}  nfs 0 0
+{myNfsSrv}:{myNFSUsrSap}/{mySid} /usr/sap/{mySid} nfs 0 0
+----
+See also manual pages SAPStartsrv_basic_cluster(8) and mount.nfs(8).
+
+==== CRM configuration fragments with simple-mount setup
 
 Find below crm configuration fragments for {sap} system {mySid}. This example
 shows the specific items for the two-node cluster with priority fencing.
-This configuration is basically the same as above, except the items shown below.
+This configuration is basically the same as above, except the Filesystem
+resources are replaced by SAPStartSrv resources.
 
 [subs="attributes"]
 ----
@@ -1735,6 +1783,8 @@ group grp_{mySid}_{myInstErs} rsc_ip_{mySid}_{myInstErs} \
     rsc_SAPStartSrv_{mySID}_{myInstErs} rsc_sap_{mySid}_{myInstErs}
 ...
 ----
+See also manual page ocf_suse_SAPStartSrv(7).
+
 
 === Corosync configuration of the two-node cluster
 

--- a/adoc/sap-nw740-sle15-setupguide.adoc
+++ b/adoc/sap-nw740-sle15-setupguide.adoc
@@ -3,7 +3,6 @@
 :slesProdVersion: 15
 
 = SAP NetWeaver Enqueue Replication 1 High Availability Cluster - SAP NetWeaver 7.40 and 7.50: Setup Guide
-//Revision {Revision} from {docdate}
 // Standard SUSE includes
 //include::common_copyright_gfdl.adoc[]
 //:toc:
@@ -115,6 +114,7 @@ include::common_intro_feedback.adoc[]
 //=== Documentation conventions
 //TODO PRIO3: work on SUSE doc standard conventions file
 //include::common_intro_typografie.adoc[]
+
 
 == Scope of this document
 
@@ -1734,8 +1734,8 @@ Mount options may depend on your particular environment.
 
 [subs="specialchars,attributes"]
 ----
-{myNfsSrv}:{myNFSSapmnt}/{mySid} /sapmnt/{mySid}  nfs 0 0
-{myNfsSrv}:{myNFSUsrSap}/{mySid} /usr/sap/{mySid} nfs 0 0
+{myNfsSrv}:/x/sapmnt/{mySid} /sapmnt/{mySid}  nfs 0 0
+{myNfsSrv}:/x/usrsap/{mySid} /usr/sap/{mySid} nfs 0 0
 ----
 See also manual pages SAPStartsrv_basic_cluster(8) and mount.nfs(8).
 
@@ -1789,6 +1789,7 @@ See also manual page ocf_suse_SAPStartSrv(7).
 === Corosync configuration of the two-node cluster
 
 Find below a corosync configuration example for one corosync ring. Ideally, two rings would be used.
+// TODO PRIO3: get corosync.conf from common include file
 
 [subs="specialchars,attributes"]
 ----
@@ -1810,7 +1811,6 @@ totem {
         mcastport: 5405
         ttl: 1
     }
-
     transport: udpu
 }
 
@@ -1834,7 +1834,6 @@ nodelist {
         ring0_addr: {myIPNode1}
         nodeid: 1
     }
-
     node {
         ring0_addr: {myIPNode2}
         nodeid: 2
@@ -1843,9 +1842,6 @@ nodelist {
 }
 
 quorum {
-
-    # Enable and configure quorum subsystem (default: off)
-    # see also corosync.conf.5 and votequorum.5
     provider: corosync_votequorum
     expected_votes: 2
     two_node: 1
@@ -1877,21 +1873,19 @@ include::common_sbp_legal_notice.adoc[]
 :leveloffset: 0
 include::common_gfdl1.2_i.adoc[]
 
-////
-Version 1.0 - Initial version based on SLE12 and NW 7.40
-Version 1.1 - Including SLE15 preparation, NW 7.50, Unicast set-up
-////
 //
-// REVISION 1.1  2018/04
+// REVISION 1.1 2018/04
 //   - PowerLE
 //   - corr: StartService
 //   - removed no-quorum-policy=ignore
 //   - corr: upper/lowercase of section titles
-// Revision 1.1a 2020/04
+// REVISION 1.1a 2020/04
 //   - migration to adoc build process
 //   - small adaption based on customer feedback
-// Revision 1.1b 2022/02
+// REVISION 1.1b 2022/02
 //   - SAP native systemd support
-// Revision 1.1b 2022/02
+// REVISION 1.1b 2022/02
 //  - small adaption based on customer feedback
+// REVISION 1.2 2023/03
+//  - simple-mount example
 //


### PR DESCRIPTION
Hi,

here are this changes:

SLES-for-SAP-hana-sr-guide-PerfOpt-12: updated references

SLES-for-SAP-hana-sr-guide-PerfOpt-15,
SLES-for-SAP-hana-scaleOut-PerfOpt-15,
SLES-for-SAP-hana-sr-guide-costopt-15,
SLES-for-SAP-hana-scaleout-multitarget-perfopt-15: native systemd integration

sap-nw740-sle15-setupguide: simple-mount appendix

Regards,
Lars