### PR TITLE
Fixed SAP DI ingress manifest

### DIFF
--- a/adoc/SAPDI3-Install.adoc
+++ b/adoc/SAPDI3-Install.adoc
@@ -325,7 +325,7 @@ In our example here, the TLS port is be {di_version}06. Note the port IP down as
 +
 ----
 $ cat <<EOF > ingress.yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
Fixing bug [396](https://github.com/SUSE/suse-best-practices/issues/396) by updating the API version of ingress to later version.