### PR TITLE
SLES4SAP-hana: SPS05 rev.059 Python 3 needed

### DIFF
--- a/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleOut-PerfOpt-15.adoc
@@ -267,7 +267,8 @@ represented by the slave mode.
 .Cluster resource agents and multi-state status mapping
 image::SAPHanaSR-ScaleOut-Cluster-Resources02.svg[scaledwidth="100%"]
 
-The second resource agent is *SAPHanaTopology*. This RA has been created to make configuring the cluster as simple as possible.
+The second resource agent is *SAPHanaTopology*. This RA has been created to make
+configuring the cluster as simple as possible.
 It runs on all nodes (except the majority maker)
 of a {sle} High Availability Extension {pn15} cluster. It gathers information
 about the statuses and configurations of the {HANA} system replication. It is
@@ -285,7 +286,7 @@ See also the requirements section below for details.
 
 Performance optimized, multi-tenancy also named MDC (%A => %B)::
 Multi-tenancy is available for all of the supported scenarios and use cases in
-this document. This scenario is supported since {HANA} 1 SPS12, it is the
+this document. This scenario is supported since {HANA} 1.0 SPS12, it is the
 default installation type for {HANA} 2.0.
 The setup and configuration from a cluster point of view is the same for
 multi-tenancy and single containers. The one caveat is, that the tenants are
@@ -375,18 +376,18 @@ following configurations and parameters:
 The systemd enabled saphostagent and instance´s sapstartsrv is supported from SAPHanaSR-ScaleOut 0.181 onwards.
 Refer to the OS documentation for the systemd version.
 {HANA} comes with native systemd integration as default starting with version 2.0 SPS07. 
-Refer to {sap} documentation for the {sap} HANA version.
+Refer to {sap} documentation for the {HANA} version.
 ** Combining systemd style hostagent with SystemV style instance is allowed.
 However, all nodes in one Linux cluster have to use the same style.
 * All {HANA} instances controlled by the cluster must not be activated via
   _sapinit_ auto-start.
 * The replication mode should be either 'sync' or 'syncmem'. But 'async' is not
   supported.
-* SAP HANA 2.0 SPS04 or later provides the HA/DR provider hook method srConnectionChanged()
-  with needed parameters for SAPHanaSrMultiTarget.py.
-* SAP HANA 2.0 SPS05 or later provides the HA/DR provider hook method srServiceStateChanged()
+* {HANA} 2.0 SPS05 rev.059 and later provides Python 3 as well as the HA/DR provider hook
+  method srConnectionChanged() with needed parameters for SAPHanaSrMultiTarget.py.
+* {HANA} 2.0 SPS05 or later provides the HA/DR provider hook method srServiceStateChanged()
   with needed parameters for susChkSrv.py.
-* SAP HANA 2.0 SPS06 or later provides the HA/DR provider hook  method preTakeover() with
+* {HANA} 2.0 SPS06 or later provides the HA/DR provider hook  method preTakeover() with
   multi-target aware parameters and separate return code for Linux HA clusters.
 * No other HA/DR provider hook script should be configured for the above mentioned methods.
   Hook scripts for other methods, provided in SAPHanaSR-ScaleOut, can  be used in parallel,
@@ -2739,9 +2740,11 @@ include::common_gfdl1.2_i.adoc[]
 
 //
 // REVISION 0.1 (2021-09-06)
-/	- copied from 12 and replaced version strings, URLs, SAP notes, TIDs
+//	- copied from 12 and replaced version strings, URLs, SAP notes, TIDs
 // REVISION 0.2 (2022-03-08)
 //	- prepared for systemd, established includes
 // REVISION 0.3 (2023-04-03)
 //	- SAP native systemd support is default for HANA 2.0 SPS07
+// REVISION 0.3a (2024-02-14)
+//      - HANA 2.0 SPS05 rev.059 Python 3 needed
 //

--- a/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
+++ b/adoc/SLES4SAP-hana-scaleout-multitarget-perfopt-15.adoc
@@ -397,11 +397,11 @@ However, all nodes in one Linux cluster have to use the same style.
   *off*.
 * The replication mode should be either 'sync' or 'syncmem'. 'async' is
   supported outside the Linux cluster.
-* SAP HANA 2.0 SPS04 or later provides the HA/DR provider hook method srConnectionChanged()
-  with needed parameters for SAPHanaSrMultiTarget.py.
-* SAP HANA 2.0 SPS05 or later provides the HA/DR provider hook method srServiceStateChanged()
+* {HANA} 2.0 SPS05 rev.059 and later provides Python 3 as well as the HA/DR provider hook
+  method srConnectionChanged() with needed parameters for SAPHanaSrMultiTarget.py.
+* {HANA} 2.0 SPS05 or later provides the HA/DR provider hook method srServiceStateChanged()
   with needed parameters for susChkSrv.py.
-* SAP HANA 2.0 SPS06 or later provides the HA/DR provider hook  method preTakeover() with
+* {HANA} 2.0 SPS06 or later provides the HA/DR provider hook  method preTakeover() with
   multi-target aware parameters and separate return code for Linux HA clusters.
 * No other HA/DR provider hook script should be configured for the above mentioned methods.
   Hook scripts for other methods, provided in SAPHanaSR-ScaleOut, can  be used in parallel,
@@ -3106,4 +3106,6 @@ include::common_gfdl1.2_i.adoc[]
 //	- prepared for systemd, established includes
 // REVISION 0.3 (2023-04-03)
 //	- SAP native systemd support is default for HANA 2.0 SPS07
+// REVISION 0.3a (2024-02-14)
+//	- HANA 2.0 SPS05 rev.059 Python 3 needed
 //

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -14,7 +14,6 @@ include::Var_SLES4SAP-hana-sr-guide-PerfOpt-15-param.txt[]
 
 // TODO PRIO1: Review all lines with "TODO PRIOx:"
 // TODO PRIO1: Check all command examples + output, if they are still valid
-// TODO PRIO1: Adding information for active/active (read-enabled) to the document
 // TODO PRIO1: Should we add a 3 nodes cluster variant with disk less fencing?
 // TODO PRIO2: Scale-Up multi sid aka MCOS for the performance optimized scenario
 // TODO PRIO1: Scale-Up with read-enabled (scheduled for 'next' publishing)
@@ -320,8 +319,9 @@ for three nodes.
 by cloud environments such as overlay IP addresses and load balancer functionality
 are also fine. Follow the cloud specific guides to set up your {sles4sap} cluster.
 * Technical users and groups, such as _{refsidadm}_ are defined
-locally in the Linux system. If that is not possible, additional measures are needed to ensure reliable
-resolution of users, groups and permissions at any time. This might include caching.
+locally in the Linux system. If that is not possible, additional measures are needed
+to ensure reliable resolution of users, groups and permissions at any time.
+This might include caching.
 * Name resolution of the cluster nodes and the virtual IP address must be done
 locally on all cluster nodes. If that is not possible, additional measures are
 needed to ensure reliable resolution of host names at any time.
@@ -406,9 +406,9 @@ memory can be used, as long as they are transparent to Linux HA.
 For the HA/DR provider hook scripts SAPHanaSR.py and susTkOver.py, the following
 requirements apply:
 
-* {HANA} 2.0 SPS04 or later provides the HA/DR provider hook method
-srConnectionChanegd() with multi-target aware parameters. {HANA} 1.0 does not
-provide them. The multi-target aware parameters are needed for the SAPHanaSR
+* {HANA} 2.0 SPS05 rev.059 and later provides Python3 as well as the HA/DR provider hook
+method srConnectionChanegd() with multi-target aware parameters. {HANA} 1.0 does not
+provide them. Python 3 and multi-target aware parameters are needed for the SAPHanaSR
 scale-up package.
 * {HANA} 2.0 SPS04 or later provides the HA/DR provider hook method preTakeover().
 // TODO PRIO1: check above version
@@ -3515,5 +3515,7 @@ include::common_gfdl1.2_i.adoc[]
 //   - updated examples, reference
 // REVISION 1.6a 2023/04
 //   - SAP native systemd support is default for HANA 2.0 SPS07
+// REVISION 1.6b 2024/02
+//      - HANA 2.0 SPS05 rev.059 Python 3 needed
 //
 

--- a/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
@@ -394,9 +394,9 @@ The {SLES4SAP} versions are:
 For the HA/DR provider hook scripts SAPHanaSR.py and susCostOpt.py, the following
 requirements apply:
 
-* {HANA} 2.0 SPS04 or later provides the HA/DR provider hook method
-srConnectionChanegd() with multi-target aware parameters. {sap} HANA 1.0 does not
-provide them. The multi-target aware parameters are needed for the SAPHanaSR
+* {HANA} 2.0 SPS05 rev.059 and later provides Python3 as well as the HA/DR provider hook
+method srConnectionChanegd() with multi-target aware parameters. {sap} HANA 1.0 does not
+provide them. Python 3 and multi-target aware parameters are needed for the SAPHanaSR
 scale-up package.
 * {HANA} 2.0 SPS04 or later provides the HA/DR provider hook method postTakeover().
 // TODO PRIO1: check above version
@@ -3970,4 +3970,6 @@ include::common_gfdl1.2_i.adoc[]
 //   - susCostOpt.py from SAPHanaSR replaced custom script {haDrCostOptMem}
 // REVISION 1.6 2023/04
 //   - SAP native systemd support is default for HANA 2.0 SPS07
+// REVISION 1.6b 2024/02
+//      - HANA 2.0 SPS05 rev.059 Python 3 needed
 //


### PR DESCRIPTION
Hi,
HANA 2.0 SPS05 rev.059 or later is needed with current SAPHanaSR and SAPHanaSR-ScaleOut.
Regards,
Lars