### PR TITLE
SAP-S4HA10-setup-simplemount-sle15.adoc: SAPStartSRv must never have monitor

### DIFF
--- a/adoc/SAP-S4HA10-setup-simplemount-sle15.adoc
+++ b/adoc/SAP-S4HA10-setup-simplemount-sle15.adoc
@@ -994,7 +994,8 @@ primitive rsc_sap_{mySID}_{myInstAscs} SAPInstance \
 The shown SAPInstance monitor timeout is a trade-off between fast recovery of
 the ASCS vs. resilience against sporadic temporary NFS issues. You may slightly
 increase it to fit your infrastructure. Consult your storage or NFS server
-documentation for appropriate timeout values.
+documentation for appropriate timeout values. Make sure the SAPStartSrv resource
+has *NO* monitor operation configured.
 See also manual pages ocf_heartbeat_SAPInstance(7), ocf_heartbeat_IPAddr2(7) ocf_suse_SAPStartSrv(7)
 and nfs(5).
 
@@ -1049,7 +1050,8 @@ primitive rsc_sap_{mySID}_{myInstErs} SAPInstance \
 The shown SAPInstance monitor timeout is a trade-off between fast recovery of
 the ERS vs. resilience against sporadic temporary NFS issues. You may slightly
 increase it to fit your infrastructure. Consult your storage or NFS server
-documentation for appropriate timeout values.
+documentation for appropriate timeout values. Make sure the SAPStartSrv resource
+has *NO* monitor operation configured.
 See also manual pages ocf_heartbeat_SAPInstance(7), ocf_heartbeat_IPAddr2(7) ocf_suse_SAPStartSrv(7)
 and nfs(5).
 


### PR DESCRIPTION
Hi,
SAP-S4HA10-setup-simplemount-sle15.adoc: SAPStartSRv must never have monitor
see also bsc #1221641.
Might go into the next docu update.
Regards,
Lars