### PR TITLE
SAP-hana setup guides: fixed typos and URLs

### DIFF
--- a/adoc/SAPNotes_HANA20_15.adoc
+++ b/adoc/SAPNotes_HANA20_15.adoc
@@ -73,7 +73,7 @@ XFS file system::
 - ocf_suse_SAPHana(7)
 - ocf_suse_SAPHanaController(7)
 - ocf_suse_SAPHanaTopology(7)
-- SAHanaSR(7)
+- SAPHanaSR(7)
 - SAPHanaSR-filter(8)
 - SAPHanaSR_basic_cluster(7)
 - SAPHanaSR-hookHelper(8)
@@ -194,6 +194,8 @@ How to patch a SAP Application Pacemaker Cluster::
 
 = Related SUSE blogs
 
+How to upgrade to SAPHanaSR-angi::
+https://www.suse.com/c/how-to-upgrade-to-saphanasr-angi/
 Emergency Braking for SAP HANA Dying Indexserver::
 https://www.suse.com/c/emergency-braking-for-sap-hana-dying-indexserver/
 SAP HANA Cockpit with SUSE HA integration greatly improves data integrity::

--- a/adoc/SAPNotes_HANA20_angi_15.adoc
+++ b/adoc/SAPNotes_HANA20_angi_15.adoc
@@ -74,9 +74,9 @@ XFS file system::
 - ocf_suse_SAPHanaFilesystem(7)
 - ocf_suse_SAPHanaTopology(7)
 - ocf_suse_SAPHanaFilesystem(7)
-- SAHanaSR(7)
-- SAHanaSR-alert-fencing(8)
-- SAHanaSR-angi(7)
+- SAPHanaSR(7)
+- SAPHanaSR-alert-fencing(8)
+- SAPHanaSR-angi(7)
 - SAPHanaSR_basic_cluster(7)
 - SAPHanaSR-hookHelper(8)
 - SAPHanaSR_maintenance_examples(7)
@@ -195,6 +195,8 @@ How to patch a SAP Application Pacemaker Cluster::
 
 = Related SUSE blogs
 
+How to upgrade to SAPHanaSR-angi::
+https://www.suse.com/c/how-to-upgrade-to-saphanasr-angi/
 Emergency Braking for SAP HANA Dying Indexserver::
 https://www.suse.com/c/emergency-braking-for-sap-hana-dying-indexserver/
 SAP HANA Cockpit with SUSE HA integration greatly improves data integrity::

--- a/adoc/SLES4SAP-hana-angi-perfopt-15.adoc
+++ b/adoc/SLES4SAP-hana-angi-perfopt-15.adoc
@@ -70,7 +70,7 @@ From the infrastructure perspective, the following variants are covered:
 - Public cloud deployment (usually needs additional documentation focusing on the cloud specific implementation details)
 
 Deployment automation simplifies roll-out. There are several options available,
-particularly on public cloud platfoms (for example https://www.suse.com/c/automating-the-sap-hana-high-availability-cluster-deployment-for-microsoft-azure/).
+particularly on public cloud platfoms.
 Ask your public cloud provider or your SUSE contact for more information.
 
 See <<cha.hana-sr.scenario>> for details.

--- a/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-PerfOpt-15.adoc
@@ -90,7 +90,7 @@ From the infrastructure perspective, the following variants are covered:
 - Public cloud deployment (usually needs additional documentation focusing on the cloud specific implementation details)
 
 Deployment automation simplifies roll-out. There are several options available,
-particularly on public cloud platfoms (for example https://www.suse.com/c/automating-the-sap-hana-high-availability-cluster-deployment-for-microsoft-azure/).
+particularly on public cloud platfoms.
 Ask your public cloud provider or your SUSE contact for details.
 
 See <<cha.hana-sr.scenario>> for details.

--- a/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
+++ b/adoc/SLES4SAP-hana-sr-guide-costopt-15.adoc
@@ -77,7 +77,7 @@ From the infrastructure perspective, the following variants are covered:
 - Public cloud deployment (usually needs additional documentation focusing on the cloud specific implementation details)
 
 Deployment automation simplifies roll-out. There are several options available,
-particularly on public cloud platfoms (for example https://www.suse.com/c/automating-the-sap-hana-high-availability-cluster-deployment-for-microsoft-azure/).
+particularly on public cloud platfoms.
 Ask your public cloud provider or your SUSE contact for details.
 
 See <<cha.hana-sr.scenario>> for details.


### PR DESCRIPTION
Hi,
fixed typos and URLs in SAP-hana scale-up setup guides.
Might go into one of the next maint. updates.
Regards,
Lars