### PR TITLE
Hotfix: RKE2 Installation

### DIFF
--- a/adoc/SAPDI3-Rancher.adoc
+++ b/adoc/SAPDI3-Rancher.adoc
@@ -185,7 +185,7 @@ Do not forget to restart or reload `haproxy` if any changes are made to the hapr
 To install RKE2, the script provided at https://get.rke2.io can be used as follows:
 [source, bash]
 ----
-$ curl -sfL https://get.rke2.io | sh -
+$ curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.28.13-rke2r1 sh
 ----
 
 For HA setups, it is necessary to create RKE2 cluster configuration files in advance.


### PR DESCRIPTION
Hotfix: We need to add the RKE2 Version, that we can install RKE2 through Rancher Prime private registry.
The current instructions will lead to a crashing installation process.