### PR TITLE
SAP-S4HA10-setupguide-sle15.adoc sap-nw740-sle15-setupguide.adoc: obsoleted by simple-mount

### DIFF
--- a/adoc/SAP-S4HA10-setupguide-sle15.adoc
+++ b/adoc/SAP-S4HA10-setupguide-sle15.adoc
@@ -54,9 +54,9 @@ for customers of different sizes and industries.
 The here described HA setup is based on cluster-controlled file systems for the
 SAP central services working directories.
 This setup with cluster-controlled file system resources has been obsoleted by the
-so-called simple-mount setup. The setup with cluster-controlled file systems still
-is supported for existing clusters.
-For deploying new HA clusters please use the simple-mount setup, described in
+so-called simple-mount setup. The setup with cluster-controlled file systems
+is still supported for existing clusters.
+For deploying new HA clusters, please use the simple-mount setup, described in
 "SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"
 (https://documentation.suse.com/sbp/sap/html/SAP_S4HA10_SetupGuide_SimpleMount-SLE15).
 
@@ -122,9 +122,9 @@ This guide focuses on the high availability of the central services. For {saphan
 consult the guides for the performance-optimized or cost-optimized scenario (see <<sec.resource>>).
 
 NOTE: This setup with cluster-controlled file system resources has been obsoleted by the
-so-called simple-mount setup. The setup with cluster-controlled file systems still
-is supported for existing clusters.
-For deploying new HA clusters please use the simple mount-setup, described in
+so-called simple-mount setup. The setup with cluster-controlled file systems
+is still supported for existing clusters.
+For deploying new HA clusters, please use the simple-mount setup, described in
 "SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"
 (https://documentation.suse.com/sbp/sap/html/SAP_S4HA10_SetupGuide_SimpleMount-SLE15).
 

--- a/adoc/SAP-S4HA10-setupguide-sle15.adoc
+++ b/adoc/SAP-S4HA10-setupguide-sle15.adoc
@@ -53,10 +53,10 @@ for customers of different sizes and industries.
 
 The here described HA setup is based on cluster-controlled file systems for the
 SAP central services working directories.
-This setup with cluster-controlled file system resources has been used in former
-HA certifications. It still is supported.
-For deploying new HA clusters, we recommend using the so-called simple mount setup,
-described in
+This setup with cluster-controlled file system resources has been obsoleted by the
+so-called simple-mount setup. The setup with cluster-controlled file systems still
+is supported for existing clusters.
+For deploying new HA clusters please use the simple-mount setup, described in
 "SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"
 (https://documentation.suse.com/sbp/sap/html/SAP_S4HA10_SetupGuide_SimpleMount-SLE15).
 
@@ -75,8 +75,8 @@ https://documentation.suse.com/sbp/sap/
 Here you can access guides for {SAPHANA} system replication
 automation and High Availability (HA) scenarios for {SAPNw} and {s4hana}.
 
-Additional resources, such as customer references, brochures or flyers, can be found at the SUSE Linux
-Enterprise Server for SAP Applications resource library:
+Additional resources, such as customer references, brochures or flyers, can be found
+at the SUSE Linux Enterprise Server for SAP Applications resource library:
 https://www.suse.com/products/sles-for-sap/resource-library/.
 
 Supported high availability solutions by {sles4sap} overview:
@@ -120,6 +120,14 @@ NOTE: This guide implements the cluster architecture for enqueue replication ver
 
 This guide focuses on the high availability of the central services. For {saphana} system replication
 consult the guides for the performance-optimized or cost-optimized scenario (see <<sec.resource>>).
+
+NOTE: This setup with cluster-controlled file system resources has been obsoleted by the
+so-called simple-mount setup. The setup with cluster-controlled file systems still
+is supported for existing clusters.
+For deploying new HA clusters please use the simple mount-setup, described in
+"SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"
+(https://documentation.suse.com/sbp/sap/html/SAP_S4HA10_SetupGuide_SimpleMount-SLE15).
+
 
 == Overview
 
@@ -2274,4 +2282,6 @@ include::common_gfdl1.2_i.adoc[]
 //	- SAP native systemd support
 // REVISION 1.2a 2022/06
 //	- small feedback from customer
+// REVISION 1.3 2024/11
+//	- this guide has been obsoleted by simple-mount setup
 //

--- a/adoc/sap-nw740-sle15-setupguide.adoc
+++ b/adoc/sap-nw740-sle15-setupguide.adoc
@@ -80,11 +80,14 @@ customers of different sizes and industries.
 
 The here described HA setup is based on cluster-controlled file systems for the
 SAP central services working directories.
-This setup with cluster-controlled file system resources has been used in former
-HA certifications. It still is supported.
-For deploying new HA clusters, we recommend using the so-called *simple mount* setup
-described in SUSE TID "Use of Filesystem resource for ASCS/ERS HA setup not possible"
-(https://www.suse.com/support/kb/doc/?id=000019944).
+This setup with cluster-controlled file system resources has been obsoleted by the
+so-called simple-mount setup. The setup with cluster-controlled file systems still
+is supported for existing clusters.
+For deploying new HA clusters please use the simple-mount setup, described in
+SUSE TID "Use of Filesystem resource for ASCS/ERS HA setup not possible"
+(https://www.suse.com/support/kb/doc/?id=000019944) and in the
+"SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"
+(https://documentation.suse.com/sbp/sap/html/SAP_S4HA10_SetupGuide_SimpleMount-SLE15).
 
 
 === Additional documentation and resources
@@ -144,6 +147,19 @@ documentation and resources").
 ////
 
 For {saphana} system replication, follow the guides for the performance- or cost-optimized scenario.
+
+NOTE: The here described HA setup is based on cluster-controlled file systems for the
+SAP central services working directories.
+This setup with cluster-controlled file system resources has been obsoleted by the
+so-called simple-mount setup. The setup with cluster-controlled file systems still
+is supported for existing clusters.
+For deploying new HA clusters please use the simple-mount setup, described in
+SUSE TID "Use of Filesystem resource for ASCS/ERS HA setup not possible"
+(https://www.suse.com/support/kb/doc/?id=000019944) and in the
+"SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"
+(https://documentation.suse.com/sbp/sap/html/SAP_S4HA10_SetupGuide_SimpleMount-SLE15).
+
+
 
 == Overview
 
@@ -1912,4 +1928,6 @@ include::common_gfdl1.2_i.adoc[]
 //  - small adaption based on customer feedback
 // REVISION 1.2 2023/03
 //  - simple-mount example
+// REVISION 1.3 2024/11
+//  - this guide is obsoleted by simple-mount setup
 //

--- a/adoc/sap-nw740-sle15-setupguide.adoc
+++ b/adoc/sap-nw740-sle15-setupguide.adoc
@@ -81,9 +81,9 @@ customers of different sizes and industries.
 The here described HA setup is based on cluster-controlled file systems for the
 SAP central services working directories.
 This setup with cluster-controlled file system resources has been obsoleted by the
-so-called simple-mount setup. The setup with cluster-controlled file systems still
-is supported for existing clusters.
-For deploying new HA clusters please use the simple-mount setup, described in
+so-called simple-mount setup. The setup with cluster-controlled file systems
+is still supported for existing clusters.
+For deploying new HA clusters, please use the simple-mount setup, described in
 SUSE TID "Use of Filesystem resource for ASCS/ERS HA setup not possible"
 (https://www.suse.com/support/kb/doc/?id=000019944) and in the
 "SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"
@@ -148,12 +148,12 @@ documentation and resources").
 
 For {saphana} system replication, follow the guides for the performance- or cost-optimized scenario.
 
-NOTE: The here described HA setup is based on cluster-controlled file systems for the
+NOTE: The HA setup described here is based on cluster-controlled file systems for the
 SAP central services working directories.
 This setup with cluster-controlled file system resources has been obsoleted by the
-so-called simple-mount setup. The setup with cluster-controlled file systems still
-is supported for existing clusters.
-For deploying new HA clusters please use the simple-mount setup, described in
+so-called simple-mount setup. The setup with cluster-controlled file systems
+is still supported for existing clusters.
+For deploying new HA clusters, please use the simple-mount setup, described in
 SUSE TID "Use of Filesystem resource for ASCS/ERS HA setup not possible"
 (https://www.suse.com/support/kb/doc/?id=000019944) and in the
 "SAP S/4 HANA - Enqueue Replication 2 High Availability Cluster With Simple Mount - Setup Guide"


### PR DESCRIPTION
Hi,
the two setup guides have been obsoleted by thesimple-mount setup.
However, the old concept still is supported for existing clusters.
The respective note might get published with the next update.
Regards,
Lars