### PR TITLE
Correct the stated reason why 538.imagick_r is slower with PGO

### DIFF
--- a/xml/MAIN-SBP-GCC-14.xml
+++ b/xml/MAIN-SBP-GCC-14.xml
@@ -1194,20 +1194,30 @@ int foo_v1 (void)
 
    <para>Many of the SPEC 2017 floating-point benchmarks measure how well a given system can
    optimize and execute a handful of number crunching loops. They often come from performance
-   sensitive programs written with traditional compilation method in mind. As a result, there are 
-   fewer cross-module dependencies, making the identification of hot paths less critical. 
-   Consequently, the overall impact of LTO and PGO on the suite is often minimal. Nevertheless, 
-   there are important cases when these modes
-   of compilation also bring about significant performance increases. Unfortunately, when using
-   PGO, GCC 14 cannot employ inlining hints that avoid severe <emphasis role="italic">store-to-load
-   forwarding stalls</emphasis> leading to performance degradation of benchmark
-   <literal>538.imagick_r</literal>. This means that the overall performance score even decreases by
-   1% when using both LTO and PGO.  <xref linkend="fig-gcc14-specfp-ofast-pgolto-perf-indiv"
+   sensitive programs written with traditional compilation method in mind. As a result, there are
+   fewer cross-module dependencies, making the identification of hot paths less critical.
+   Consequently, the overall impact of LTO and PGO on the suite is often minimal. Nevertheless,
+   there are important cases when these modes of compilation also bring about significant
+   performance increases.  <xref linkend="fig-gcc14-specfp-ofast-pgolto-perf-indiv"
    xrefstyle="template:Figure %n"/> shows the effect of these methods on individual benchmarks when
    compiled at <literal>-&#8288;Ofast</literal> and targeting the full ISA of the AMD EPYC 9755
    Processor. Furthermore, binary size savings of PGO and LTO are sometimes even bigger than those
    achieved on integer benchmarks, as can be seen in <xref
    linkend="fig-gcc14-specfp-ofast-pgolto-size" xrefstyle="template:figure %n"/></para>
+
+   <para>Unfortunately, in the case of <literal>538.imagick_r</literal> benchmark there is a big
+   mismatch in between the code paths exercised in the train run which is used to measure which
+   parts of the program need to be optimized for speed and the actual reference run which is then
+   used to obtain the benchmark score.  This is exactly the problem we warn against in <xref
+   linkend="sec-gcc14-pgo"/> and it has the predictable detrimental effect on performance.<footnote>
+   <para>See <link xlink:href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111551">GCC bug
+   111551</link> for more details.</para></footnote> Moreover, because the important loop, which is
+   not appropriately optimized because it is not executed in the train run, is in a function in
+   which there is another loop which is heavily executed in the train run, even using the
+   <literal>-&#8288;fprofile-partial-training</literal> does not help to mitigate the problem.  This
+   is essentialy a bug in the SPEC CPU suite and it means that the overall performance score even
+   decreases by 1% when using both LTO and PGO.
+   </para>
 
     <!--
    <figure xml:id="fig-gcc12-specfp-ofast-pgolto-geomean">


### PR DESCRIPTION
After the GCC 14 SBP got published, our colleague Jan Hubička completed his detailed analysis why 538.imagick_r is slower when built with PGO and the reason is actually different from what we stated in the first version of the paper.  This commit replaces the incorrect one with the correct one.