### PR TITLE
Update AMD Tuning Guides for AMD EPYC 4 and 5 Processors

### DIFF
--- a/images/src/svg/EPYC4-nas-2vms-sev.svg
+++ b/images/src/svg/EPYC4-nas-2vms-sev.svg
@@ -1,104 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="294mm" height="165mm" viewBox="0 0 29400 16500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
- <path fill="rgb(255,255,255)" stroke="none" d="M 14691,16528 L -13,16528 -13,-13 29394,-13 29394,16528 14691,16528 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15704,15551 L 2602,15551 2602,1299 28806,1299 28806,15551 15704,15551 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,15550 L 2602,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,14124 L 2602,14124 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,12699 L 2602,12699 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,11274 L 2602,11274 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,9848 L 2602,9848 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,8423 L 2602,8423 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,6999 L 2602,6999 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,5573 L 2602,5573 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,4148 L 2602,4148 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,2723 L 2602,2723 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,1298 L 2602,1298 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15700 L 2602,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15700 L 2602,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6345,15700 L 6345,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6345,15700 L 6345,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 10089,15700 L 10089,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 10089,15700 L 10089,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13832,15700 L 13832,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13832,15700 L 13832,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17575,15700 L 17575,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17575,15700 L 17575,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 21318,15700 L 21318,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 21318,15700 L 21318,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25062,15700 L 25062,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25062,15700 L 25062,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,15700 L 28806,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,15700 L 28806,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15550 L 28806,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,15550 L 2602,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,15550 L 2602,15550 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,14124 L 2602,14124 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,14124 L 2602,14124 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,12699 L 2602,12699 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,12699 L 2602,12699 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,11274 L 2602,11274 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,11274 L 2602,11274 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,9848 L 2602,9848 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,9848 L 2602,9848 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,8423 L 2602,8423 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,8423 L 2602,8423 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,6999 L 2602,6999 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,6999 L 2602,6999 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,5573 L 2602,5573 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,5573 L 2602,5573 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,4148 L 2602,4148 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,4148 L 2602,4148 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,2723 L 2602,2723 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,2723 L 2602,2723 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,1298 L 2602,1298 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,1298 L 2602,1298 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15550 L 2602,1298 "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 3069,15550 L 4005,15550 4005,9841 3069,9841 3069,15550 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 6813,15550 L 7749,15550 7749,13376 6813,13376 6813,15550 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 10557,15550 L 11492,15550 11492,15395 10557,15395 10557,15550 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 14300,15550 L 15235,15550 15235,15460 14300,15460 14300,15550 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 18043,15550 L 18979,15550 18979,12247 18043,12247 18043,15550 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 21786,15550 L 22722,15550 22722,14907 21786,14907 21786,15550 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 25530,15550 L 26466,15550 26466,3059 25530,3059 25530,15550 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 4005,15550 L 4941,15550 4941,9844 4005,9844 4005,15550 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 7749,15550 L 8685,15550 8685,13382 7749,13382 7749,15550 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 11492,15550 L 12428,15550 12428,15392 11492,15392 11492,15550 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 15235,15550 L 16171,15550 16171,15463 15235,15463 15235,15550 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 18979,15550 L 19915,15550 19915,12249 18979,12249 18979,15550 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 22722,15550 L 23658,15550 23658,14909 22722,14909 22722,15550 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 26466,15550 L 27402,15550 27402,3051 26466,3051 26466,15550 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 4941,15550 L 5877,15550 5877,9838 4941,9838 4941,15550 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 8685,15550 L 9621,15550 9621,13377 8685,13377 8685,15550 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 12428,15550 L 13364,15550 13364,15393 12428,15393 12428,15550 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 16171,15550 L 17107,15550 17107,15463 16171,15463 16171,15550 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 19915,15550 L 20850,15550 20850,12245 19915,12245 19915,15550 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 23658,15550 L 24594,15550 24594,14908 23658,14908 23658,15550 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 27402,15550 L 28338,15550 28338,3043 27402,3043 27402,15550 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4158" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7864" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11597" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15408" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="19142" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="22780" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="26581" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="2161" y="15671"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="14245"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="12820"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="11395"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="9969"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="8544"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="7120"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="5694"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="4269"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="2844"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">900</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="1419"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1000</tspan></tspan></tspan></text>
- <path fill="rgb(0,69,134)" stroke="none" d="M 12173,576 L 12068,576 12068,365 12279,365 12279,576 12173,576 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 14611,576 L 14506,576 14506,365 14716,365 14716,576 14611,576 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 15844,576 L 15738,576 15738,365 15949,365 15949,576 15844,576 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12379" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">unencrypted</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14816" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16049" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
- <text class="SVGTextShape" transform="rotate(-90 825 9398)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9398"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14571" y="8401"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13286,14947 L -13,14947 -13,-13 26584,-13 26584,14947 13286,14947 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14203,14001 L 2354,14001 2354,1269 26053,1269 26053,14001 14203,14001 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,10180 L 2354,10180 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,6361 L 2354,6361 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,3814 L 2354,3814 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,2541 L 2354,2541 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,1268 L 2354,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10180 L 2354,10180 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10180 L 2354,10180 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6361 L 2354,6361 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6361 L 2354,6361 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3814 L 2354,3814 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3814 L 2354,3814 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2541 L 2354,2541 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2541 L 2354,2541 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1268 L 2354,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1268 L 2354,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 2354,1268 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2777,14000 L 3623,14000 3623,7486 2777,7486 2777,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6162,14000 L 7009,14000 7009,11649 6162,11649 6162,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9548,14000 L 10395,14000 10395,13757 9548,13757 9548,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12934,14000 L 13779,14000 13779,13893 12934,13893 12934,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16319,14000 L 17165,14000 17165,10213 16319,10213 16319,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 19704,14000 L 20551,14000 20551,13374 19704,13374 19704,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 23090,14000 L 23936,14000 23936,2779 23090,2779 23090,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3623,14000 L 4470,14000 4470,7249 3623,7249 3623,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7009,14000 L 7855,14000 7855,11583 7009,11583 7009,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10395,14000 L 11241,14000 11241,13763 10395,13763 10395,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13779,14000 L 14626,14000 14626,13894 13779,13894 13779,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 17165,14000 L 18011,14000 18011,10184 17165,10184 17165,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 20551,14000 L 21397,14000 21397,13363 20551,13363 20551,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 23936,14000 L 24783,14000 24783,2661 23936,2661 23936,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4470,14000 L 5316,14000 5316,7194 4470,7194 4470,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 7855,14000 L 8702,14000 8702,11592 7855,11592 7855,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11241,14000 L 12087,14000 12087,13756 11241,13756 11241,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14626,14000 L 15472,14000 15472,13898 14626,13898 14626,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 18011,14000 L 18858,14000 18858,10174 18011,10174 18011,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 21397,14000 L 22244,14000 22244,13361 21397,13361 21397,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 24783,14000 L 25629,14000 25629,2590 24783,2590 24783,14000 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3731" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7079" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10455" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13908" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17283" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20564" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24007" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1913" y="14121"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="12847"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="11574"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">150</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="9027"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="7754"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">250</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6482"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="5208"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">350</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="3935"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="2662"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">450</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1389"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10768,576 L 10663,576 10663,365 10874,365 10874,576 10768,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13206,576 L 13101,576 13101,365 13311,365 13311,576 13206,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14439,576 L 14333,576 14333,365 14544,365 14544,576 14439,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10974" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">unencrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13411" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14644" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8608)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8608"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13166" y="7610"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
 </svg>

--- a/images/src/svg/EPYC4-nas-2vms-sev.svg
+++ b/images/src/svg/EPYC4-nas-2vms-sev.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13286,14947 L -13,14947 -13,-13 26584,-13 26584,14947 13286,14947 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14203,14001 L 2354,14001 2354,1269 26053,1269 26053,14001 14203,14001 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,10180 L 2354,10180 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,6361 L 2354,6361 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,3814 L 2354,3814 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,2541 L 2354,2541 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,1268 L 2354,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10180 L 2354,10180 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10180 L 2354,10180 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6361 L 2354,6361 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6361 L 2354,6361 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3814 L 2354,3814 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3814 L 2354,3814 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2541 L 2354,2541 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2541 L 2354,2541 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1268 L 2354,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1268 L 2354,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 2354,1268 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2777,14000 L 3623,14000 3623,7486 2777,7486 2777,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6162,14000 L 7009,14000 7009,11649 6162,11649 6162,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9548,14000 L 10395,14000 10395,13757 9548,13757 9548,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12934,14000 L 13779,14000 13779,13893 12934,13893 12934,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16319,14000 L 17165,14000 17165,10213 16319,10213 16319,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 19704,14000 L 20551,14000 20551,13374 19704,13374 19704,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 23090,14000 L 23936,14000 23936,2779 23090,2779 23090,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3623,14000 L 4470,14000 4470,7249 3623,7249 3623,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7009,14000 L 7855,14000 7855,11583 7009,11583 7009,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10395,14000 L 11241,14000 11241,13763 10395,13763 10395,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13779,14000 L 14626,14000 14626,13894 13779,13894 13779,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 17165,14000 L 18011,14000 18011,10184 17165,10184 17165,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 20551,14000 L 21397,14000 21397,13363 20551,13363 20551,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 23936,14000 L 24783,14000 24783,2661 23936,2661 23936,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4470,14000 L 5316,14000 5316,7194 4470,7194 4470,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 7855,14000 L 8702,14000 8702,11592 7855,11592 7855,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11241,14000 L 12087,14000 12087,13756 11241,13756 11241,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14626,14000 L 15472,14000 15472,13898 14626,13898 14626,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 18011,14000 L 18858,14000 18858,10174 18011,10174 18011,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 21397,14000 L 22244,14000 22244,13361 21397,13361 21397,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 24783,14000 L 25629,14000 25629,2590 24783,2590 24783,14000 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3731" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7079" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10455" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13908" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17283" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20564" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24007" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1913" y="14121"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="12847"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="11574"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">150</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="9027"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="7754"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">250</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6482"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="5208"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">350</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="3935"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="2662"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">450</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1389"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10768,576 L 10663,576 10663,365 10874,365 10874,576 10768,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13206,576 L 13101,576 13101,365 13311,365 13311,576 13206,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14439,576 L 14333,576 14333,365 14544,365 14544,576 14439,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10974" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">unencrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13411" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14644" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8608)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8608"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13166" y="7610"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-nas-2vms-sev.svg
+++ b/images/src/svg/EPYC4-nas-2vms-sev.svg
@@ -1,104 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
- <path fill="rgb(255,255,255)" stroke="none" d="M 13286,14947 L -13,14947 -13,-13 26584,-13 26584,14947 13286,14947 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14203,14001 L 2354,14001 2354,1269 26053,1269 26053,14001 14203,14001 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14000 L 2354,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,12726 L 2354,12726 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,11453 L 2354,11453 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,10180 L 2354,10180 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,8906 L 2354,8906 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,7633 L 2354,7633 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,6361 L 2354,6361 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,5087 L 2354,5087 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,3814 L 2354,3814 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,2541 L 2354,2541 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,1268 L 2354,1268 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 26053,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10180 L 2354,10180 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10180 L 2354,10180 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6361 L 2354,6361 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6361 L 2354,6361 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3814 L 2354,3814 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3814 L 2354,3814 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2541 L 2354,2541 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2541 L 2354,2541 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1268 L 2354,1268 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1268 L 2354,1268 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 2354,1268 "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 2777,14000 L 3623,14000 3623,7486 2777,7486 2777,14000 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 6162,14000 L 7009,14000 7009,11649 6162,11649 6162,14000 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 9548,14000 L 10395,14000 10395,13757 9548,13757 9548,14000 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 12934,14000 L 13779,14000 13779,13893 12934,13893 12934,14000 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 16319,14000 L 17165,14000 17165,10213 16319,10213 16319,14000 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 19704,14000 L 20551,14000 20551,13374 19704,13374 19704,14000 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 23090,14000 L 23936,14000 23936,2779 23090,2779 23090,14000 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 3623,14000 L 4470,14000 4470,7249 3623,7249 3623,14000 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 7009,14000 L 7855,14000 7855,11583 7009,11583 7009,14000 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 10395,14000 L 11241,14000 11241,13763 10395,13763 10395,14000 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 13779,14000 L 14626,14000 14626,13894 13779,13894 13779,14000 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 17165,14000 L 18011,14000 18011,10184 17165,10184 17165,14000 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 20551,14000 L 21397,14000 21397,13363 20551,13363 20551,14000 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 23936,14000 L 24783,14000 24783,2661 23936,2661 23936,14000 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 4470,14000 L 5316,14000 5316,7194 4470,7194 4470,14000 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 7855,14000 L 8702,14000 8702,11592 7855,11592 7855,14000 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 11241,14000 L 12087,14000 12087,13756 11241,13756 11241,14000 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 14626,14000 L 15472,14000 15472,13898 14626,13898 14626,14000 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 18011,14000 L 18858,14000 18858,10174 18011,10174 18011,14000 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 21397,14000 L 22244,14000 22244,13361 21397,13361 21397,14000 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 24783,14000 L 25629,14000 25629,2590 24783,2590 24783,14000 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3731" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7079" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10455" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13908" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17283" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20564" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24007" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1913" y="14121"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="12847"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="11574"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">150</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="9027"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="7754"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">250</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6482"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="5208"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">350</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="3935"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="2662"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">450</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1389"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
- <path fill="rgb(0,69,134)" stroke="none" d="M 10768,576 L 10663,576 10663,365 10874,365 10874,576 10768,576 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 13206,576 L 13101,576 13101,365 13311,365 13311,576 13206,576 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 14439,576 L 14333,576 14333,365 14544,365 14544,576 14439,576 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10974" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">unencrypted</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13411" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14644" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
- <text class="SVGTextShape" transform="rotate(-90 825 8608)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8608"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13166" y="7610"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+<svg width="294mm" height="165mm" viewBox="0 0 29400 16500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 14691,16528 L -13,16528 -13,-13 29394,-13 29394,16528 14691,16528 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15704,15551 L 2602,15551 2602,1299 28806,1299 28806,15551 15704,15551 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,15550 L 2602,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,14124 L 2602,14124 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,12699 L 2602,12699 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,11274 L 2602,11274 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,9848 L 2602,9848 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,8423 L 2602,8423 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,6999 L 2602,6999 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,5573 L 2602,5573 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,4148 L 2602,4148 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,2723 L 2602,2723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,1298 L 2602,1298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15700 L 2602,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15700 L 2602,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6345,15700 L 6345,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6345,15700 L 6345,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 10089,15700 L 10089,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 10089,15700 L 10089,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13832,15700 L 13832,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13832,15700 L 13832,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17575,15700 L 17575,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17575,15700 L 17575,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 21318,15700 L 21318,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 21318,15700 L 21318,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25062,15700 L 25062,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25062,15700 L 25062,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,15700 L 28806,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28806,15700 L 28806,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15550 L 28806,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,15550 L 2602,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,15550 L 2602,15550 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,14124 L 2602,14124 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,14124 L 2602,14124 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,12699 L 2602,12699 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,12699 L 2602,12699 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,11274 L 2602,11274 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,11274 L 2602,11274 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,9848 L 2602,9848 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,9848 L 2602,9848 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,8423 L 2602,8423 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,8423 L 2602,8423 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,6999 L 2602,6999 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,6999 L 2602,6999 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,5573 L 2602,5573 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,5573 L 2602,5573 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,4148 L 2602,4148 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,4148 L 2602,4148 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,2723 L 2602,2723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,2723 L 2602,2723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,1298 L 2602,1298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2452,1298 L 2602,1298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2602,15550 L 2602,1298 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 3069,15550 L 4005,15550 4005,9841 3069,9841 3069,15550 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6813,15550 L 7749,15550 7749,13376 6813,13376 6813,15550 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10557,15550 L 11492,15550 11492,15395 10557,15395 10557,15550 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 14300,15550 L 15235,15550 15235,15460 14300,15460 14300,15550 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 18043,15550 L 18979,15550 18979,12247 18043,12247 18043,15550 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 21786,15550 L 22722,15550 22722,14907 21786,14907 21786,15550 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 25530,15550 L 26466,15550 26466,3059 25530,3059 25530,15550 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4005,15550 L 4941,15550 4941,9844 4005,9844 4005,15550 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7749,15550 L 8685,15550 8685,13382 7749,13382 7749,15550 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 11492,15550 L 12428,15550 12428,15392 11492,15392 11492,15550 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15235,15550 L 16171,15550 16171,15463 15235,15463 15235,15550 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 18979,15550 L 19915,15550 19915,12249 18979,12249 18979,15550 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 22722,15550 L 23658,15550 23658,14909 22722,14909 22722,15550 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 26466,15550 L 27402,15550 27402,3051 26466,3051 26466,15550 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4941,15550 L 5877,15550 5877,9838 4941,9838 4941,15550 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8685,15550 L 9621,15550 9621,13377 8685,13377 8685,15550 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12428,15550 L 13364,15550 13364,15393 12428,15393 12428,15550 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 16171,15550 L 17107,15550 17107,15463 16171,15463 16171,15550 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 19915,15550 L 20850,15550 20850,12245 19915,12245 19915,15550 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 23658,15550 L 24594,15550 24594,14908 23658,14908 23658,15550 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 27402,15550 L 28338,15550 28338,3043 27402,3043 27402,15550 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4158" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7864" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11597" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15408" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="19142" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="22780" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="26581" y="16118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="2161" y="15671"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="14245"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="12820"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="11395"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="9969"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="8544"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="7120"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="5694"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="4269"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1778" y="2844"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">900</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="1419"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1000</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12173,576 L 12068,576 12068,365 12279,365 12279,576 12173,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 14611,576 L 14506,576 14506,365 14716,365 14716,576 14611,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 15844,576 L 15738,576 15738,365 15949,365 15949,576 15844,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12379" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">unencrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14816" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16049" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9398)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9398"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14571" y="8401"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
 </svg>

--- a/images/src/svg/EPYC4-nas-bm-12vm.svg
+++ b/images/src/svg/EPYC4-nas-bm-12vm.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13286,14947 L -13,14947 -13,-13 26584,-13 26584,14947 13286,14947 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14299,14001 L 2545,14001 2545,1269 26053,1269 26053,14001 14299,14001 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14000 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,12181 L 2545,12181 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,10362 L 2545,10362 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,8543 L 2545,8543 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,6724 L 2545,6724 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,4906 L 2545,4906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,3086 L 2545,3086 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,1267 L 2545,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14150 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14150 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5903,14150 L 5903,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5903,14150 L 5903,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9261,14150 L 9261,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9261,14150 L 9261,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12620,14150 L 12620,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12620,14150 L 12620,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15977,14150 L 15977,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15977,14150 L 15977,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19336,14150 L 19336,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19336,14150 L 19336,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22694,14150 L 22694,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22694,14150 L 22694,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14000 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,14000 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,14000 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,12181 L 2545,12181 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,12181 L 2545,12181 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,10362 L 2545,10362 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,10362 L 2545,10362 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,8543 L 2545,8543 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,8543 L 2545,8543 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,6724 L 2545,6724 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,6724 L 2545,6724 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,4905 L 2545,4905 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,4905 L 2545,4905 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,3086 L 2545,3086 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,3086 L 2545,3086 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,1267 L 2545,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,1267 L 2545,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14000 L 2545,1267 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2824,14000 L 3384,14000 3384,13565 2824,13565 2824,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6183,14000 L 6743,14000 6743,13819 6183,13819 6183,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9541,14000 L 10101,14000 10101,13981 9541,13981 9541,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12900,14000 L 13458,14000 13458,13992 12900,13992 12900,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16257,14000 L 16817,14000 16817,13722 16257,13722 16257,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 19616,14000 L 20175,14000 20175,13954 19616,13954 19616,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 22974,14000 L 23534,14000 23534,13393 22974,13393 22974,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 3384,14000 L 3944,14000 3944,13069 3384,13069 3384,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 6743,14000 L 7302,14000 7302,13664 6743,13664 6743,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10101,14000 L 10661,14000 10661,13965 10101,13965 10101,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 13458,14000 L 14018,14000 14018,13984 13458,13984 13458,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 16817,14000 L 17377,14000 17377,13459 16817,13459 16817,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 20175,14000 L 20735,14000 20735,13910 20175,13910 20175,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 23534,14000 L 24093,14000 24093,12396 23534,12396 23534,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 3944,14000 L 4504,14000 4504,12050 3944,12050 3944,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 7302,14000 L 7862,14000 7862,13425 7302,13425 7302,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 10661,14000 L 11220,14000 11220,13931 10661,13931 10661,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 14018,14000 L 14578,14000 14578,13971 14018,13971 14018,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17377,14000 L 17936,14000 17936,12961 17377,12961 17377,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 20735,14000 L 21295,14000 21295,13793 20735,13793 20735,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 24093,14000 L 24653,14000 24653,10460 24093,10460 24093,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 4504,14000 L 5063,14000 5063,11081 4504,11081 4504,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 7862,14000 L 8422,14000 8422,13129 7862,13129 7862,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11220,14000 L 11780,14000 11780,13871 11220,13871 11220,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14578,14000 L 15138,14000 15138,13957 14578,13957 14578,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 17936,14000 L 18496,14000 18496,12256 17936,12256 17936,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 21295,14000 L 21854,14000 21854,13658 21295,13658 21295,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 24653,14000 L 25213,14000 25213,8673 24653,8673 24653,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 5063,14000 L 5623,14000 5623,8411 5063,8411 5063,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 8422,14000 L 8981,14000 8981,12297 8422,12297 8422,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 11780,14000 L 12340,14000 12340,13800 11780,13800 11780,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 15138,14000 L 15697,14000 15697,13924 15138,13924 15138,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 18496,14000 L 19056,14000 19056,7246 18496,7246 18496,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 21854,14000 L 22414,14000 22414,13330 21854,13330 21854,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 25213,14000 L 25773,14000 25773,3371 25213,3371 25213,14000 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3909" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7229" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10578" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14003" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17351" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20605" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24020" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="2104" y="14121"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="12302"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="10483"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1000</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="8664"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6845"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2000</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="5026"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="3207"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">3000</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1388"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">3500</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9401,576 L 9296,576 9296,365 9507,365 9507,576 9401,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12029,576 L 11924,576 11924,365 12135,365 12135,576 12029,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13377,576 L 13272,576 13272,365 13482,365 13482,576 13377,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14725,576 L 14619,576 14619,365 14830,365 14830,576 14725,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 16073,576 L 15967,576 15967,365 16178,365 16178,576 16073,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9607" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BAREMETAL</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12235" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13582" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14930" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">6 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16278" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">12 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8608)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8608"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13166" y="7610"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-nas-bm-1vm.svg
+++ b/images/src/svg/EPYC4-nas-bm-1vm.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13286,14947 L -13,14947 -13,-13 26584,-13 26584,14947 13286,14947 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14203,14001 L 2354,14001 2354,1268 26053,1268 26053,14001 14203,14001 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,10179 L 2354,10179 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,6360 L 2354,6360 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,3813 L 2354,3813 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,2540 L 2354,2540 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,1267 L 2354,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12726 L 2354,12726 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11453 L 2354,11453 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10179 L 2354,10179 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10179 L 2354,10179 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8906 L 2354,8906 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6360 L 2354,6360 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6360 L 2354,6360 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5087 L 2354,5087 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3813 L 2354,3813 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3813 L 2354,3813 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2540 L 2354,2540 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2540 L 2354,2540 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1267 L 2354,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1267 L 2354,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 2354,1267 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2918,14000 L 4046,14000 4046,6390 2918,6390 2918,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6304,14000 L 7432,14000 7432,10838 6304,10838 6304,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9689,14000 L 10818,14000 10818,13673 9689,13673 9689,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 13075,14000 L 14203,14000 14203,13868 13075,13868 13075,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16460,14000 L 17588,14000 17588,9141 16460,9141 16460,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 19845,14000 L 20974,14000 20974,13198 19845,13198 19845,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 23231,14000 L 24360,14000 24360,3387 23231,3387 23231,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4046,14000 L 5175,14000 5175,5347 4046,5347 4046,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7432,14000 L 8561,14000 8561,10348 7432,10348 7432,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10818,14000 L 11946,14000 11946,13588 10818,13588 10818,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 14203,14000 L 15331,14000 15331,13858 14203,13858 14203,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 17588,14000 L 18717,14000 18717,8673 17588,8673 17588,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 20974,14000 L 22103,14000 22103,13109 20974,13109 20974,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 24360,14000 L 25488,14000 25488,2328 24360,2328 24360,14000 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3731" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7079" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10455" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13908" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17283" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20564" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24007" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1913" y="14121"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="12847"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="11574"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="10300"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="9027"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">80</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="7754"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6481"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">120</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="5208"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">140</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="3934"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">160</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="2661"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">180</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1388"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 11519,576 L 11414,576 11414,365 11625,365 11625,576 11519,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 14147,576 L 14041,576 14041,365 14252,365 14252,576 14147,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11725" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BAREMETAL</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14352" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8608)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8608"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13166" y="7610"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-bm-1vm.svg
+++ b/images/src/svg/EPYC4-stream-bm-1vm.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="294mm" height="153mm" viewBox="0 0 29400 15300" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 14692,15260 L -13,15260 -13,-13 29397,-13 29397,15260 14692,15260 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15610,13327 L 2411,13327 2411,1772 28809,1772 28809,13327 15610,13327 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,13326 L 2411,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,11675 L 2411,11675 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,10024 L 2411,10024 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,8373 L 2411,8373 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,6723 L 2411,6723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,5072 L 2411,5072 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,3421 L 2411,3421 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,1771 L 2411,1771 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2411,13476 L 2411,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2411,13476 L 2411,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9010,13476 L 9010,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9010,13476 L 9010,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15609,13476 L 15609,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15609,13476 L 15609,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22209,13476 L 22209,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22209,13476 L 22209,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,13476 L 28809,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28809,13476 L 28809,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2411,13326 L 28809,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,13326 L 2411,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,13326 L 2411,13326 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,11675 L 2411,11675 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,11675 L 2411,11675 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,10024 L 2411,10024 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,10024 L 2411,10024 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,8373 L 2411,8373 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,8373 L 2411,8373 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,6723 L 2411,6723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,6723 L 2411,6723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,5072 L 2411,5072 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,5072 L 2411,5072 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,3421 L 2411,3421 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,3421 L 2411,3421 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,1771 L 2411,1771 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2261,1771 L 2411,1771 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2411,13326 L 2411,1771 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2960,13326 L 4060,13326 4060,12454 2960,12454 2960,13326 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9560,13326 L 10660,13326 10660,12722 9560,12722 9560,13326 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16159,13326 L 17259,13326 17259,12702 16159,12702 16159,13326 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 22759,13326 L 23859,13326 23859,12677 22759,12677 22759,13326 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4060,13326 L 5160,13326 5160,12445 4060,12445 4060,13326 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10660,13326 L 11760,13326 11760,12673 10660,12673 10660,13326 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 17259,13326 L 18359,13326 18359,12660 17259,12660 17259,13326 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 23859,13326 L 24959,13326 24959,12644 23859,12644 23859,13326 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 5160,13326 L 6260,13326 6260,2759 5160,2759 5160,13326 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11760,13326 L 12860,13326 12860,5658 11760,5658 11760,13326 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 18359,13326 L 19459,13326 19459,4789 18359,4789 18359,13326 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 24959,13326 L 26059,13326 26059,4518 24959,4518 24959,13326 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 6260,13326 L 7360,13326 7360,3325 6260,3325 6260,13326 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 12860,13326 L 13960,13326 13960,6305 12860,6305 12860,13326 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 19459,13326 L 20559,13326 20559,5687 19459,5687 19459,13326 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 26059,13326 L 27159,13326 27159,5632 26059,5632 26059,13326 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 7360,13326 L 8460,13326 8460,3154 7360,3154 7360,13326 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 13960,13326 L 15059,13326 15059,6107 13960,6107 13960,13326 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 20559,13326 L 21659,13326 21659,5647 20559,5647 20559,13326 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 27159,13326 L 28259,13326 28259,5495 27159,5495 27159,13326 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="5309" y="13894"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11881" y="13894"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="18604" y="13894"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="25118" y="13894"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1970" y="13447"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="11796"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="10145"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="8494"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="6844"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="5193"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="3542"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1587" y="1892"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6735,576 L 6630,576 6630,365 6841,365 6841,576 6735,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 11180,576 L 11075,576 11075,365 11286,365 11286,576 11180,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17279,576 L 17173,576 17173,365 17384,365 17384,576 17279,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 6735,1074 L 6630,1074 6630,863 6841,863 6841,1074 6735,1074 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11180,1074 L 11075,1074 11075,863 11286,863 11286,1074 11180,1074 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="6941" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BM, single</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11386" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM, single</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17484" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BM, openmp (2xLLCs=48 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="6941" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BM, openmp (36 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11386" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM, openmp (2xLLCs=36 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13796" y="14666"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9476)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9476"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Bandwidth (GBytes/sec)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-omp-1vm-model.svg
+++ b/images/src/svg/EPYC4-stream-omp-1vm-model.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="228mm" height="128mm" viewBox="0 0 22800 12800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 11391,12815 L -13,12815 -13,-13 22795,-13 22795,12815 11391,12815 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12309,10931 L 2279,10931 2279,1724 22339,1724 22339,10931 12309,10931 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,10930 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,9614 L 2279,9614 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,8299 L 2279,8299 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,6983 L 2279,6983 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,5669 L 2279,5669 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,4353 L 2279,4353 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,3038 L 2279,3038 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,1723 L 2279,1723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,11080 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,11080 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7294,11080 L 7294,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7294,11080 L 7294,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12308,11080 L 12308,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12308,11080 L 12308,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17323,11080 L 17323,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17323,11080 L 17323,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,11080 L 22339,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22339,11080 L 22339,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,10930 L 22339,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,10930 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,10930 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,9614 L 2279,9614 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,9614 L 2279,9614 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,8299 L 2279,8299 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,8299 L 2279,8299 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,6983 L 2279,6983 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,6983 L 2279,6983 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,5669 L 2279,5669 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,5669 L 2279,5669 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,4353 L 2279,4353 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,4353 L 2279,4353 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,3038 L 2279,3038 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,3038 L 2279,3038 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,1723 L 2279,1723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,1723 L 2279,1723 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,10930 L 2279,1723 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2637,10930 L 3353,10930 3353,2825 2637,2825 2637,10930 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7652,10930 L 8368,10930 8368,5178 7652,5178 7652,10930 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12666,10930 L 13383,10930 13383,4812 12666,4812 12666,10930 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 17681,10930 L 18398,10930 18398,4690 17681,4690 17681,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3353,10930 L 4070,10930 4070,2815 3353,2815 3353,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 8368,10930 L 9085,10930 9085,5188 8368,5188 8368,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13383,10930 L 14099,10930 14099,4830 13383,4830 13383,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 18398,10930 L 19114,10930 19114,4716 18398,4716 18398,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4070,10930 L 4786,10930 4786,8274 4070,8274 4070,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 9085,10930 L 9801,10930 9801,9008 9085,9008 9085,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14099,10930 L 14816,10930 14816,8960 14099,8960 14099,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 19114,10930 L 19831,10930 19831,8851 19114,8851 19114,10930 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 4786,10930 L 5503,10930 5503,8281 4786,8281 4786,10930 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 9801,10930 L 10518,10930 10518,9008 9801,9008 9801,10930 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 14816,10930 L 15532,10930 15532,8961 14816,8961 14816,10930 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 19831,10930 L 20547,10930 20547,8852 19831,8852 19831,10930 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 5503,10930 L 6219,10930 6219,2846 5503,2846 5503,10930 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 10518,10930 L 11234,10930 11234,5162 10518,5162 10518,10930 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 15532,10930 L 16249,10930 16249,4802 15532,4802 15532,10930 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 20547,10930 L 21264,10930 21264,4676 20547,4676 20547,10930 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 6219,10930 L 6936,10930 6936,2775 6219,2775 6219,10930 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 11234,10930 L 11950,10930 11950,5174 11234,5174 11234,10930 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 16249,10930 L 16965,10930 16965,4778 16249,4778 16249,10930 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 21264,10930 L 21980,10930 21980,4627 21264,4627 21264,10930 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4385" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9372" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14511" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="19440" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1838" y="11051"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="9735"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="8420"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="7104"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="5790"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="4474"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="3159"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="1844"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 1525,576 L 1420,576 1420,365 1631,365 1631,576 1525,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 8820,576 L 8715,576 8715,365 8926,365 8926,576 8820,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 15464,576 L 15358,576 15358,365 15569,365 15569,576 15464,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 1525,1074 L 1420,1074 1420,863 1631,863 1631,1074 1525,1074 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 8820,1074 L 8715,1074 8715,863 8926,863 8926,1074 8820,1074 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 15464,1074 L 15358,1074 15358,863 15569,863 15569,1074 15464,1074 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1731" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre"> cpumodel  (2xLLCs=36 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9026" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpumodel+haltpoll (2xLLCs=36 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15669" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthough (2xLLCs=4 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1731" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthough+haltpoll (2xLLCs=4 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9026" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough (36 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15669" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough+haltpoll (36 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10495" y="12221"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 7362)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7362"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-omp-vms-avg.svg
+++ b/images/src/svg/EPYC4-stream-omp-vms-avg.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="206mm" height="116mm" viewBox="0 0 20600 11600" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 10305,11594 L -13,11594 -13,-13 20623,-13 20623,11594 10305,11594 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11223,9734 L 2235,9734 2235,1201 20211,1201 20211,9734 11223,9734 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,8513 L 2235,8513 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,7294 L 2235,7294 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,6075 L 2235,6075 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,4857 L 2235,4857 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,3638 L 2235,3638 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,2419 L 2235,2419 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9883 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9883 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6729,9883 L 6729,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6729,9883 L 6729,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11222,9883 L 11222,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11222,9883 L 11222,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15716,9883 L 15716,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15716,9883 L 15716,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9733 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,8513 L 2235,8513 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,8513 L 2235,8513 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,7294 L 2235,7294 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,7294 L 2235,7294 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,6075 L 2235,6075 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,6075 L 2235,6075 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,4857 L 2235,4857 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,4857 L 2235,4857 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,3638 L 2235,3638 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,3638 L 2235,3638 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,2419 L 2235,2419 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,2419 L 2235,2419 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9733 L 2235,1200 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2556,9733 L 3198,9733 3198,2212 2556,2212 2556,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7050,9733 L 7692,9733 7692,4412 7050,4412 7050,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 11543,9733 L 12185,9733 12185,4080 11543,4080 11543,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16037,9733 L 16679,9733 16679,3974 16037,3974 16037,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3198,9733 L 3840,9733 3840,5867 3198,5867 3198,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7692,9733 L 8334,9733 8334,7007 7692,7007 7692,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 12185,9733 L 12827,9733 12827,6682 12185,6682 12185,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16679,9733 L 17321,9733 17321,6631 16679,6631 16679,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 3840,9733 L 4482,9733 4482,7696 3840,7696 3840,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8334,9733 L 8976,9733 8976,8385 8334,8385 8334,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12827,9733 L 13469,9733 13469,8188 12827,8188 12827,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17321,9733 L 17963,9733 17963,8134 17321,8134 17321,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 4482,9733 L 5124,9733 5124,8212 4482,8212 4482,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 8976,9733 L 9618,9733 9618,8723 8976,8723 8976,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13469,9733 L 14111,9733 14111,8656 13469,8656 13469,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17963,9733 L 18605,9733 18605,8539 17963,8539 17963,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 5124,9733 L 5766,9733 5766,9018 5124,9018 5124,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 9618,9733 L 10260,9733 10260,9262 9618,9262 9618,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14111,9733 L 14753,9733 14753,9212 14111,9212 14111,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 18605,9733 L 19247,9733 19247,9099 18605,9099 18605,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 5766,9733 L 6408,9733 6408,9359 5766,9359 5766,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 10260,9733 L 10901,9733 10901,9486 10260,9486 10260,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 14753,9733 L 15395,9733 15395,9460 14753,9460 14753,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 19247,9733 L 19889,9733 19889,9402 19247,9402 19247,9733 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4081" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8547" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13164" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17572" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1794" y="9854"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="8634"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="7415"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="6196"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="4978"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="3759"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="2540"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="1321"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6291,576 L 6186,576 6186,365 6397,365 6397,576 6291,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7639,576 L 7534,576 7534,365 7745,365 7745,576 7639,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8987,576 L 8882,576 8882,365 9093,365 9093,576 8987,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 10335,576 L 10230,576 10230,365 10440,365 10440,576 10335,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11683,576 L 11577,576 11577,365 11788,365 11788,576 11683,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 13222,576 L 13116,576 13116,365 13327,365 13327,576 13222,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="6497" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7845" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9193" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10540" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">6 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11888" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">12 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13427" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">24 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9409" y="11000"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 7985)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7985"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-omp-vms-sum.svg
+++ b/images/src/svg/EPYC4-stream-omp-vms-sum.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="206mm" height="116mm" viewBox="0 0 20600 11600" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 10305,11594 L -13,11594 -13,-13 20623,-13 20623,11594 10305,11594 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11223,9734 L 2235,9734 2235,1201 20211,1201 20211,9734 11223,9734 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,8666 L 2235,8666 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,7599 L 2235,7599 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,6532 L 2235,6532 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,5467 L 2235,5467 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,4400 L 2235,4400 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,3333 L 2235,3333 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,2266 L 2235,2266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9883 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9883 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6729,9883 L 6729,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6729,9883 L 6729,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11222,9883 L 11222,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11222,9883 L 11222,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15716,9883 L 15716,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15716,9883 L 15716,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9733 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,8666 L 2235,8666 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,8666 L 2235,8666 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,7599 L 2235,7599 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,7599 L 2235,7599 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,6532 L 2235,6532 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,6532 L 2235,6532 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,5467 L 2235,5467 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,5467 L 2235,5467 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,4400 L 2235,4400 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,4400 L 2235,4400 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,3333 L 2235,3333 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,3333 L 2235,3333 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,2266 L 2235,2266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,2266 L 2235,2266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9733 L 2235,1200 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2556,9733 L 3198,9733 3198,3152 2556,3152 2556,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7050,9733 L 7692,9733 7692,5077 7050,5077 7050,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 11543,9733 L 12185,9733 12185,4787 11543,4787 11543,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16037,9733 L 16679,9733 16679,4694 16037,4694 16037,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3198,9733 L 3840,9733 3840,2968 3198,2968 3198,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7692,9733 L 8334,9733 8334,4964 7692,4964 7692,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 12185,9733 L 12827,9733 12827,4395 12185,4395 12185,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16679,9733 L 17321,9733 17321,4305 16679,4305 16679,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 3840,9733 L 4482,9733 4482,2607 3840,2607 3840,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8334,9733 L 8976,9733 8976,5017 8334,5017 8334,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12827,9733 L 13469,9733 13469,4328 12827,4328 12827,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17321,9733 L 17963,9733 17963,4140 17321,4140 17321,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 4482,9733 L 5124,9733 5124,1753 4482,1753 4482,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 8976,9733 L 9618,9733 9618,4432 8976,4432 8976,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13469,9733 L 14111,9733 14111,4081 13469,4081 13469,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17963,9733 L 18605,9733 18605,3470 17963,3470 17963,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 5124,9733 L 5766,9733 5766,2226 5124,2226 5124,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 9618,9733 L 10260,9733 10260,4793 9618,4793 9618,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14111,9733 L 14753,9733 14753,4271 14111,4271 14111,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 18605,9733 L 19247,9733 19247,3079 18605,3079 18605,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 5766,9733 L 6408,9733 6408,1898 5766,1898 5766,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 10260,9733 L 10901,9733 10901,4565 10260,4565 10260,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 14753,9733 L 15395,9733 15395,4012 14753,4012 14753,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 19247,9733 L 19889,9733 19889,2796 19247,2796 19247,9733 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4081" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8547" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13164" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17572" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1794" y="9854"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="8787"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="7720"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="6653"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="5588"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="4521"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="3454"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="2387"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="1321"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6291,576 L 6186,576 6186,365 6397,365 6397,576 6291,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7639,576 L 7534,576 7534,365 7745,365 7745,576 7639,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8987,576 L 8882,576 8882,365 9093,365 9093,576 8987,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 10335,576 L 10230,576 10230,365 10440,365 10440,576 10335,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11683,576 L 11577,576 11577,365 11788,365 11788,576 11683,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 13222,576 L 13116,576 13116,365 13327,365 13327,576 13222,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="6497" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7845" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9193" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10540" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">6 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11888" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">12 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13427" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">24 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9409" y="11000"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 7985)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7985"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-openmp-sev-avg.svg
+++ b/images/src/svg/EPYC4-stream-openmp-sev-avg.svg
@@ -1,74 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="228mm" height="128mm" viewBox="0 0 22800 12800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
- <path fill="rgb(255,255,255)" stroke="none" d="M 11390,12815 L -13,12815 -13,-13 22793,-13 22793,12815 11390,12815 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12308,10931 L 2279,10931 2279,1225 22337,1225 22337,10931 12308,10931 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,10930 L 2279,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,9543 L 2279,9543 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,8156 L 2279,8156 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,6769 L 2279,6769 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,5384 L 2279,5384 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,3997 L 2279,3997 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,2610 L 2279,2610 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,1224 L 2279,1224 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,11080 L 2279,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,11080 L 2279,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7293,11080 L 7293,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7293,11080 L 7293,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12307,11080 L 12307,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12307,11080 L 12307,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17322,11080 L 17322,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17322,11080 L 17322,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,11080 L 22337,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,11080 L 22337,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,10930 L 22337,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,10930 L 2279,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,10930 L 2279,10930 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,9543 L 2279,9543 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,9543 L 2279,9543 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,8156 L 2279,8156 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,8156 L 2279,8156 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,6769 L 2279,6769 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,6769 L 2279,6769 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,5384 L 2279,5384 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,5384 L 2279,5384 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,3997 L 2279,3997 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,3997 L 2279,3997 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,2610 L 2279,2610 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,2610 L 2279,2610 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,1224 L 2279,1224 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,1224 L 2279,1224 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,10930 L 2279,1224 "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 2905,10930 L 4159,10930 4159,2136 2905,2136 2905,10930 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 7920,10930 L 9174,10930 9174,4731 7920,4731 7920,10930 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 12934,10930 L 14188,10930 14188,3990 12934,3990 12934,10930 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 17949,10930 L 19202,10930 19202,3874 17949,3874 17949,10930 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 4159,10930 L 5413,10930 5413,2249 4159,2249 4159,10930 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 9174,10930 L 10427,10930 10427,4845 9174,4845 9174,10930 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 14188,10930 L 15441,10930 15441,4058 14188,4058 14188,10930 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 19202,10930 L 20456,10930 20456,3946 19202,3946 19202,10930 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 5413,10930 L 6666,10930 6666,2274 5413,2274 5413,10930 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 10427,10930 L 11680,10930 11680,4868 10427,4868 10427,10930 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 15441,10930 L 16695,10930 16695,4080 15441,4080 15441,10930 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 20456,10930 L 21710,10930 21710,3966 20456,3966 20456,10930 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4385" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9372" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14509" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="19438" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1838" y="11051"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1646" y="9664"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="8277"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="6890"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">150</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="5505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="4118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">250</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="2731"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="1345"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">350</tspan></tspan></tspan></text>
- <path fill="rgb(0,69,134)" stroke="none" d="M 8776,576 L 8671,576 8671,365 8882,365 8882,576 8776,576 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 11405,576 L 11300,576 11300,365 11510,365 11510,576 11405,576 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 12638,576 L 12532,576 12532,365 12743,365 12743,576 12638,576 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8982" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">not encrypted</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11610" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12843" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10415" y="12221"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operations</tspan></tspan></tspan></text>
- <text class="SVGTextShape" transform="rotate(-90 825 7113)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7113"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+<svg width="265mm" height="149mm" viewBox="0 0 26500 14900" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13258,14915 L -13,14915 -13,-13 26529,-13 26529,14915 13258,14915 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14176,12989 L 2353,12989 2353,1267 25999,1267 25999,12989 14176,12989 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,12988 L 2353,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,10643 L 2353,10643 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,8298 L 2353,8298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,5955 L 2353,5955 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,3610 L 2353,3610 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,1266 L 2353,1266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,13138 L 2353,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,13138 L 2353,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8264,13138 L 8264,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8264,13138 L 8264,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14175,13138 L 14175,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14175,13138 L 14175,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20087,13138 L 20087,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20087,13138 L 20087,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,13138 L 25999,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25999,13138 L 25999,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,12988 L 25999,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,12988 L 2353,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,12988 L 2353,12988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,10643 L 2353,10643 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,10643 L 2353,10643 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,8298 L 2353,8298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,8298 L 2353,8298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,5955 L 2353,5955 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,5955 L 2353,5955 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,3610 L 2353,3610 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,3610 L 2353,3610 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,1266 L 2353,1266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,1266 L 2353,1266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,12988 L 2353,1266 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 3091,12988 L 4569,12988 4569,4178 3091,4178 3091,12988 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9003,12988 L 10481,12988 10481,7455 9003,7455 9003,12988 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 14914,12988 L 16392,12988 16392,6691 14914,6691 14914,12988 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 20826,12988 L 22304,12988 22304,6522 20826,6522 20826,12988 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4569,12988 L 6047,12988 6047,4076 4569,4076 4569,12988 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10481,12988 L 11959,12988 11959,7440 10481,7440 10481,12988 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16392,12988 L 17870,12988 17870,6684 16392,6684 16392,12988 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 22304,12988 L 23782,12988 23782,6439 22304,6439 22304,12988 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 6047,12988 L 7525,12988 7525,3899 6047,3899 6047,12988 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11959,12988 L 13436,12988 13436,7482 11959,7482 11959,12988 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17870,12988 L 19348,12988 19348,6690 17870,6690 17870,12988 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 23782,12988 L 25260,12988 25260,6399 23782,6399 23782,12988 Z "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3830,4355 L 3830,4178 3830,4002 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3930,4355 L 3730,4355 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3730,4002 L 3930,4002 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 9742,7507 L 9742,7455 9742,7404 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 9842,7507 L 9642,7507 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 9642,7404 L 9842,7404 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 15653,6713 L 15653,6691 15653,6670 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 15753,6713 L 15553,6713 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 15553,6670 L 15753,6670 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 21565,6669 L 21565,6522 21565,6375 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 21665,6669 L 21465,6669 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 21465,6375 L 21665,6375 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 5308,4214 L 5308,4076 5308,3937 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 5408,4214 L 5208,4214 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 5208,3937 L 5408,3937 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11220,7467 L 11220,7440 11220,7412 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11320,7467 L 11120,7467 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11120,7412 L 11320,7412 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 17131,6687 L 17131,6684 17131,6681 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 17231,6687 L 17031,6687 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 17031,6681 L 17231,6681 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 23043,6674 L 23043,6439 23043,6204 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 23143,6674 L 22943,6674 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 22943,6204 L 23143,6204 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6786,3963 L 6786,3899 6786,3834 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6886,3963 L 6686,3963 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6686,3834 L 6886,3834 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 12698,7579 L 12698,7482 12698,7386 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 12798,7579 L 12598,7579 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 12598,7386 L 12798,7386 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18609,6711 L 18609,6690 18609,6669 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18709,6711 L 18509,6711 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18509,6669 L 18709,6669 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 24521,6661 L 24521,6399 24521,6138 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 24621,6661 L 24421,6661 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 24421,6138 L 24621,6138 "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4907" y="13556"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10791" y="13556"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16826" y="13556"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="22652" y="13556"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1912" y="13109"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1720" y="10764"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="8419"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="6076"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">150</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="3731"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="1387"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">250</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10644,576 L 10539,576 10539,365 10750,365 10750,576 10644,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13273,576 L 13168,576 13168,365 13378,365 13378,576 13273,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14506,576 L 14400,576 14400,365 14611,365 14611,576 14506,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10850" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">not encrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13479" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14711" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12283" y="14321"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operations</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8163)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8163"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
 </svg>

--- a/images/src/svg/EPYC4-stream-openmp-sev-avg.svg
+++ b/images/src/svg/EPYC4-stream-openmp-sev-avg.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="228mm" height="128mm" viewBox="0 0 22800 12800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 11390,12815 L -13,12815 -13,-13 22793,-13 22793,12815 11390,12815 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12308,10931 L 2279,10931 2279,1225 22337,1225 22337,10931 12308,10931 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,10930 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,9543 L 2279,9543 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,8156 L 2279,8156 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,6769 L 2279,6769 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,5384 L 2279,5384 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,3997 L 2279,3997 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,2610 L 2279,2610 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,1224 L 2279,1224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,11080 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,11080 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7293,11080 L 7293,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7293,11080 L 7293,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12307,11080 L 12307,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12307,11080 L 12307,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17322,11080 L 17322,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17322,11080 L 17322,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,11080 L 22337,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22337,11080 L 22337,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,10930 L 22337,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,10930 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,10930 L 2279,10930 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,9543 L 2279,9543 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,9543 L 2279,9543 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,8156 L 2279,8156 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,8156 L 2279,8156 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,6769 L 2279,6769 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,6769 L 2279,6769 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,5384 L 2279,5384 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,5384 L 2279,5384 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,3997 L 2279,3997 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,3997 L 2279,3997 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,2610 L 2279,2610 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,2610 L 2279,2610 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,1224 L 2279,1224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2129,1224 L 2279,1224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2279,10930 L 2279,1224 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2905,10930 L 4159,10930 4159,2136 2905,2136 2905,10930 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7920,10930 L 9174,10930 9174,4731 7920,4731 7920,10930 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12934,10930 L 14188,10930 14188,3990 12934,3990 12934,10930 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 17949,10930 L 19202,10930 19202,3874 17949,3874 17949,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4159,10930 L 5413,10930 5413,2249 4159,2249 4159,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9174,10930 L 10427,10930 10427,4845 9174,4845 9174,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 14188,10930 L 15441,10930 15441,4058 14188,4058 14188,10930 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 19202,10930 L 20456,10930 20456,3946 19202,3946 19202,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 5413,10930 L 6666,10930 6666,2274 5413,2274 5413,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10427,10930 L 11680,10930 11680,4868 10427,4868 10427,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 15441,10930 L 16695,10930 16695,4080 15441,4080 15441,10930 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 20456,10930 L 21710,10930 21710,3966 20456,3966 20456,10930 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4385" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9372" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14509" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="19438" y="11498"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1838" y="11051"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1646" y="9664"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="8277"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="6890"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">150</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="5505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="4118"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">250</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="2731"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="1345"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">350</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8776,576 L 8671,576 8671,365 8882,365 8882,576 8776,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 11405,576 L 11300,576 11300,365 11510,365 11510,576 11405,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12638,576 L 12532,576 12532,365 12743,365 12743,576 12638,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8982" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">not encrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11610" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12843" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10415" y="12221"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operations</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 7113)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7113"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-single-1vm-model.svg
+++ b/images/src/svg/EPYC4-stream-single-1vm-model.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="330mm" height="185mm" viewBox="0 0 33000 18500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 16467,18526 L -13,18526 -13,-13 32947,-13 32947,18526 16467,18526 Z "/>
+ <path fill="rgb(255,255,255)" stroke="none" d="M 17289,16528 L 2291,16528 2291,1339 32288,1339 32288,16528 17289,16528 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17289,16528 L 2291,16528 2291,1339 32288,1339 32288,16528 17289,16528 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,16527 L 2291,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,13995 L 2291,13995 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,11463 L 2291,11463 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,8933 L 2291,8933 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,6401 L 2291,6401 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,3869 L 2291,3869 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,1338 L 2291,1338 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2291,16677 L 2291,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2291,16677 L 2291,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9790,16677 L 9790,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9790,16677 L 9790,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17289,16677 L 17289,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17289,16677 L 17289,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24788,16677 L 24788,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24788,16677 L 24788,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,16677 L 32288,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 32288,16677 L 32288,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2291,16527 L 32288,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,16527 L 2291,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,16527 L 2291,16527 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,13995 L 2291,13995 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,13995 L 2291,13995 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,11463 L 2291,11463 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,11463 L 2291,11463 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,8933 L 2291,8933 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,8933 L 2291,8933 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,6401 L 2291,6401 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,6401 L 2291,6401 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,3869 L 2291,3869 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,3869 L 2291,3869 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,1338 L 2291,1338 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2141,1338 L 2291,1338 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2291,16527 L 2291,1338 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 3040,16527 L 4540,16527 4540,3031 3040,3031 3040,16527 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10540,16527 L 12040,16527 12040,6517 10540,6517 10540,16527 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 18038,16527 L 19538,16527 19538,6315 18038,6315 18038,16527 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 25538,16527 L 27038,16527 27038,6069 25538,6069 25538,16527 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4540,16527 L 6040,16527 6040,3363 4540,3363 4540,16527 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 12040,16527 L 13540,16527 13540,6662 12040,6662 12040,16527 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 19538,16527 L 21038,16527 21038,6689 19538,6689 19538,16527 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 27038,16527 L 28538,16527 28538,6376 27038,6376 27038,16527 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 6040,16527 L 7540,16527 7540,3067 6040,3067 6040,16527 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 13540,16527 L 15040,16527 15040,6532 13540,6532 13540,16527 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 21038,16527 L 22538,16527 22538,6467 21038,6467 21038,16527 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 28538,16527 L 30038,16527 30038,6117 28538,6117 28538,16527 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 7540,16527 L 9040,16527 9040,3054 7540,3054 7540,16527 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 15040,16527 L 16539,16527 16539,6560 15040,6560 15040,16527 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 22538,16527 L 24038,16527 24038,6338 22538,6338 22538,16527 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 30038,16527 L 31538,16527 31538,6092 30038,6092 30038,16527 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="5639" y="17095"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13111" y="17095"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20733" y="17095"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="28147" y="17095"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1850" y="16648"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1658" y="14116"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">10</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1658" y="11584"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1658" y="9054"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">30</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1658" y="6522"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1658" y="3990"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1658" y="1459"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10320,576 L 10215,576 10215,365 10426,365 10426,576 10320,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 12452,576 L 12347,576 12347,365 12558,365 12558,576 12452,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 15779,576 L 15674,576 15674,365 15885,365 15885,576 15779,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 18772,576 L 18666,576 18666,365 18877,365 18877,576 18772,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10526" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre"> cpumodel</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12658" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpumodel+haltpoll</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15985" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="18977" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough+haltpoll</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15571" y="17932"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9969)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9969"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-single-sev-avg.svg
+++ b/images/src/svg/EPYC4-stream-single-sev-avg.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="228mm" height="128mm" viewBox="0 0 22800 12800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 11397,12822 L -13,12822 -13,-13 22806,-13 22806,12822 11397,12822 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12219,10938 L 2088,10938 2088,1225 22350,1225 22350,10938 12219,10938 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,10937 L 2088,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,9318 L 2088,9318 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,7699 L 2088,7699 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,6081 L 2088,6081 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,4462 L 2088,4462 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,2843 L 2088,2843 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,1224 L 2088,1224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,11087 L 2088,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,11087 L 2088,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7153,11087 L 7153,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7153,11087 L 7153,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12218,11087 L 12218,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12218,11087 L 12218,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17284,11087 L 17284,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17284,11087 L 17284,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,11087 L 22350,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,11087 L 22350,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,10937 L 22350,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,10937 L 2088,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,10937 L 2088,10937 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,9318 L 2088,9318 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,9318 L 2088,9318 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,7699 L 2088,7699 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,7699 L 2088,7699 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,6081 L 2088,6081 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,6081 L 2088,6081 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,4462 L 2088,4462 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,4462 L 2088,4462 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,2843 L 2088,2843 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,2843 L 2088,2843 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,1224 L 2088,1224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,1224 L 2088,1224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,10937 L 2088,1224 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2721,10937 L 3987,10937 3987,2340 2721,2340 2721,10937 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7786,10937 L 9053,10937 9053,4547 7786,4547 7786,10937 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12851,10937 L 14118,10937 14118,4419 12851,4419 12851,10937 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 17917,10937 L 19183,10937 19183,4289 17917,4289 17917,10937 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3987,10937 L 5254,10937 5254,2486 3987,2486 3987,10937 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9053,10937 L 10319,10937 10319,5095 9053,5095 9053,10937 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 14118,10937 L 15384,10937 15384,4847 14118,4847 14118,10937 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 19183,10937 L 20450,10937 20450,4656 19183,4656 19183,10937 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 5254,10937 L 6520,10937 6520,2490 5254,2490 5254,10937 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10319,10937 L 11585,10937 11585,5099 10319,5099 10319,10937 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 15384,10937 L 16651,10937 16651,4835 15384,4835 15384,10937 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 20450,10937 L 21716,10937 21716,4649 20450,4649 20450,10937 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4219" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9257" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14446" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="19426" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1647" y="11058"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="9439"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">10</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="7820"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="6202"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">30</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="4583"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="2964"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="1345"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8783,576 L 8678,576 8678,365 8889,365 8889,576 8783,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 11412,576 L 11307,576 11307,365 11517,365 11517,576 11412,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12645,576 L 12539,576 12539,365 12750,365 12750,576 12645,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8989" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">not encrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11617" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12850" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10421" y="12228"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operations</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 7117)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7117"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-single-sev-avg.svg
+++ b/images/src/svg/EPYC4-stream-single-sev-avg.svg
@@ -1,70 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="228mm" height="128mm" viewBox="0 0 22800 12800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
- <path fill="rgb(255,255,255)" stroke="none" d="M 11397,12822 L -13,12822 -13,-13 22806,-13 22806,12822 11397,12822 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12219,10938 L 2088,10938 2088,1225 22350,1225 22350,10938 12219,10938 Z "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,10937 L 2088,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,9318 L 2088,9318 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,7699 L 2088,7699 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,6081 L 2088,6081 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,4462 L 2088,4462 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,2843 L 2088,2843 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,1224 L 2088,1224 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,11087 L 2088,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,11087 L 2088,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7153,11087 L 7153,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7153,11087 L 7153,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12218,11087 L 12218,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12218,11087 L 12218,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17284,11087 L 17284,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17284,11087 L 17284,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,11087 L 22350,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22350,11087 L 22350,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,10937 L 22350,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,10937 L 2088,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,10937 L 2088,10937 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,9318 L 2088,9318 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,9318 L 2088,9318 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,7699 L 2088,7699 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,7699 L 2088,7699 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,6081 L 2088,6081 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,6081 L 2088,6081 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,4462 L 2088,4462 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,4462 L 2088,4462 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,2843 L 2088,2843 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,2843 L 2088,2843 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,1224 L 2088,1224 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1938,1224 L 2088,1224 "/>
- <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2088,10937 L 2088,1224 "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 2721,10937 L 3987,10937 3987,2340 2721,2340 2721,10937 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 7786,10937 L 9053,10937 9053,4547 7786,4547 7786,10937 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 12851,10937 L 14118,10937 14118,4419 12851,4419 12851,10937 Z "/>
- <path fill="rgb(0,69,134)" stroke="none" d="M 17917,10937 L 19183,10937 19183,4289 17917,4289 17917,10937 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 3987,10937 L 5254,10937 5254,2486 3987,2486 3987,10937 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 9053,10937 L 10319,10937 10319,5095 9053,5095 9053,10937 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 14118,10937 L 15384,10937 15384,4847 14118,4847 14118,10937 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 19183,10937 L 20450,10937 20450,4656 19183,4656 19183,10937 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 5254,10937 L 6520,10937 6520,2490 5254,2490 5254,10937 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 10319,10937 L 11585,10937 11585,5099 10319,5099 10319,10937 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 15384,10937 L 16651,10937 16651,4835 15384,4835 15384,10937 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 20450,10937 L 21716,10937 21716,4649 20450,4649 20450,10937 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4219" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9257" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14446" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="19426" y="11505"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1647" y="11058"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="9439"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">10</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="7820"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="6202"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">30</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="4583"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="2964"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1455" y="1345"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
- <path fill="rgb(0,69,134)" stroke="none" d="M 8783,576 L 8678,576 8678,365 8889,365 8889,576 8783,576 Z "/>
- <path fill="rgb(255,66,14)" stroke="none" d="M 11412,576 L 11307,576 11307,365 11517,365 11517,576 11412,576 Z "/>
- <path fill="rgb(255,211,32)" stroke="none" d="M 12645,576 L 12539,576 12539,365 12750,365 12750,576 12645,576 Z "/>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8989" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">not encrypted</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11617" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12850" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
- <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10421" y="12228"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operations</tspan></tspan></tspan></text>
- <text class="SVGTextShape" transform="rotate(-90 825 7117)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7117"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+<svg width="276mm" height="155mm" viewBox="0 0 27600 15500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13799,15525 L -13,15525 -13,-13 27612,-13 27612,15525 13799,15525 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14622,13588 L 2184,13588 2184,1280 27060,1280 27060,13588 14622,13588 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,13586 L 2184,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,11828 L 2184,11828 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,10070 L 2184,10070 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,8311 L 2184,8311 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,6554 L 2184,6554 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,4795 L 2184,4795 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,3037 L 2184,3037 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,1278 L 2184,1278 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2184,13736 L 2184,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2184,13736 L 2184,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8403,13736 L 8403,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8403,13736 L 8403,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14621,13736 L 14621,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14621,13736 L 14621,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20840,13736 L 20840,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20840,13736 L 20840,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,13736 L 27059,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27059,13736 L 27059,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2184,13586 L 27059,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,13586 L 2184,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,13586 L 2184,13586 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,11828 L 2184,11828 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,11828 L 2184,11828 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,10070 L 2184,10070 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,10070 L 2184,10070 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,8311 L 2184,8311 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,8311 L 2184,8311 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,6554 L 2184,6554 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,6554 L 2184,6554 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,4795 L 2184,4795 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,4795 L 2184,4795 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,3037 L 2184,3037 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,3037 L 2184,3037 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,1278 L 2184,1278 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2034,1278 L 2184,1278 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2184,13586 L 2184,1278 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2961,13586 L 4516,13586 4516,3439 2961,3439 2961,13586 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9180,13586 L 10735,13586 10735,9470 9180,9470 9180,13586 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 15398,13586 L 16953,13586 16953,8410 15398,8410 15398,13586 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 21618,13586 L 23172,13586 23172,8353 21618,8353 21618,13586 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4516,13586 L 6071,13586 6071,3415 4516,3415 4516,13586 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10735,13586 L 12290,13586 12290,9562 10735,9562 10735,13586 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16953,13586 L 18508,13586 18508,8496 16953,8496 16953,13586 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 23172,13586 L 24727,13586 24727,8428 23172,8428 23172,13586 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 6071,13586 L 7625,13586 7625,3503 6071,3503 6071,13586 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12290,13586 L 13844,13586 13844,9544 12290,9544 12290,13586 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 18508,13586 L 20063,13586 20063,8478 18508,8478 18508,13586 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 24727,13586 L 26282,13586 26282,8445 24727,8445 24727,13586 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4892" y="14154"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11083" y="14154"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17426" y="14154"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="23559" y="14154"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="13707"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">34</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="11949"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">36</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="10191"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">38</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="8432"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="6675"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">42</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="4916"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">44</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="3158"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">46</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1551" y="1399"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">48</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 11186,576 L 11081,576 11081,365 11292,365 11292,576 11186,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13815,576 L 13710,576 13710,365 13920,365 13920,576 13815,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 15048,576 L 14942,576 14942,365 15153,365 15153,576 15048,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11392" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">not encrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14020" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15253" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12824" y="14931"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operations</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8468)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8468"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
 </svg>

--- a/images/src/svg/EPYC4-stream-single-vms-avg.svg
+++ b/images/src/svg/EPYC4-stream-single-vms-avg.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="206mm" height="116mm" viewBox="0 0 20600 11600" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 10305,11594 L -13,11594 -13,-13 20623,-13 20623,11594 10305,11594 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11127,9734 L 2044,9734 2044,1201 20211,1201 20211,9734 11127,9734 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9733 L 2044,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,8310 L 2044,8310 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,6888 L 2044,6888 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,5467 L 2044,5467 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,4044 L 2044,4044 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,2622 L 2044,2622 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,1200 L 2044,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2044,9883 L 2044,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2044,9883 L 2044,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6586,9883 L 6586,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6586,9883 L 6586,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11127,9883 L 11127,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11127,9883 L 11127,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15669,9883 L 15669,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15669,9883 L 15669,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2044,9733 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,9733 L 2044,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,9733 L 2044,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,8310 L 2044,8310 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,8310 L 2044,8310 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,6888 L 2044,6888 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,6888 L 2044,6888 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,5467 L 2044,5467 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,5467 L 2044,5467 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,4044 L 2044,4044 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,4044 L 2044,4044 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,2622 L 2044,2622 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,2622 L 2044,2622 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,1200 L 2044,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 1894,1200 L 2044,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2044,9733 L 2044,1200 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2368,9733 L 3017,9733 3017,2337 2368,2337 2368,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6910,9733 L 7559,9733 7559,4191 6910,4191 6910,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 11451,9733 L 12100,9733 12100,4206 11451,4206 11451,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 15993,9733 L 16642,9733 16642,4030 15993,4030 15993,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3017,9733 L 3666,9733 3666,2180 3017,2180 3017,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7559,9733 L 8208,9733 8208,4120 7559,4120 7559,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 12100,9733 L 12749,9733 12749,4007 12100,4007 12100,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16642,9733 L 17291,9733 17291,3893 16642,3893 16642,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 3666,9733 L 4315,9733 4315,2337 3666,2337 3666,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8208,9733 L 8857,9733 8857,4408 8208,4408 8208,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12749,9733 L 13398,9733 13398,4245 12749,4245 12749,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17291,9733 L 17939,9733 17939,4011 17291,4011 17291,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 4315,9733 L 4963,9733 4963,2565 4315,2565 4315,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 8857,9733 L 9505,9733 9505,4713 8857,4713 8857,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13398,9733 L 14046,9733 14046,4466 13398,4466 13398,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17940,9733 L 18588,9733 18588,4195 17940,4195 17940,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 4963,9733 L 5612,9733 5612,4053 4963,4053 4963,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 9505,9733 L 10154,9733 10154,5694 9505,5694 9505,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14046,9733 L 14695,9733 14695,5203 14046,5203 14046,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 18588,9733 L 19237,9733 19237,4872 18588,4872 18588,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 5612,9733 L 6261,9733 6261,5962 5612,5962 5612,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 10154,9733 L 10802,9733 10802,7037 10154,7037 10154,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 14695,9733 L 15344,9733 15344,6758 14695,6758 14695,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 19237,9733 L 19886,9733 19886,6393 19237,6393 19237,9733 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3914" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8428" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13093" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17549" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1603" y="9854"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="8431"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">10</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="7009"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="5588"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">30</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="4165"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="2743"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="1321"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6291,576 L 6186,576 6186,365 6397,365 6397,576 6291,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7639,576 L 7534,576 7534,365 7745,365 7745,576 7639,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8987,576 L 8882,576 8882,365 9093,365 9093,576 8987,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 10335,576 L 10230,576 10230,365 10440,365 10440,576 10335,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11683,576 L 11577,576 11577,365 11788,365 11788,576 11683,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 13222,576 L 13116,576 13116,365 13327,365 13327,576 13222,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="6497" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7845" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9193" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10540" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">6 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11888" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">12 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13427" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">24 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9409" y="11000"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 7985)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7985"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC4-stream-single-vms-sum.svg
+++ b/images/src/svg/EPYC4-stream-single-vms-sum.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="206mm" height="116mm" viewBox="0 0 20600 11600" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 10305,11594 L -13,11594 -13,-13 20623,-13 20623,11594 10305,11594 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11223,9734 L 2235,9734 2235,1201 20211,1201 20211,9734 11223,9734 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,8513 L 2235,8513 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,7294 L 2235,7294 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,6075 L 2235,6075 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,4857 L 2235,4857 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,3638 L 2235,3638 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,2419 L 2235,2419 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9883 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9883 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6729,9883 L 6729,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 6729,9883 L 6729,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11222,9883 L 11222,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11222,9883 L 11222,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15716,9883 L 15716,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15716,9883 L 15716,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20211,9883 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9733 L 20211,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,9733 L 2235,9733 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,8513 L 2235,8513 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,8513 L 2235,8513 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,7294 L 2235,7294 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,7294 L 2235,7294 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,6075 L 2235,6075 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,6075 L 2235,6075 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,4857 L 2235,4857 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,4857 L 2235,4857 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,3638 L 2235,3638 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,3638 L 2235,3638 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,2419 L 2235,2419 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,2419 L 2235,2419 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2085,1200 L 2235,1200 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2235,9733 L 2235,1200 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2556,9733 L 3198,9733 3198,9099 2556,9099 2556,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7050,9733 L 7692,9733 7692,9257 7050,9257 7050,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 11543,9733 L 12185,9733 12185,9259 11543,9259 11543,9733 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16037,9733 L 16679,9733 16679,9244 16037,9244 16037,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3198,9733 L 3840,9733 3840,8438 3198,8438 3198,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7692,9733 L 8334,9733 8334,8770 7692,8770 7692,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 12185,9733 L 12827,9733 12827,8751 12185,8751 12185,9733 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16679,9733 L 17321,9733 17321,8731 16679,8731 16679,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 3840,9733 L 4482,9733 4482,7197 3840,7197 3840,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8334,9733 L 8976,9733 8976,7906 8334,7906 8334,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12827,9733 L 13469,9733 13469,7851 12827,7851 12827,9733 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17321,9733 L 17963,9733 17963,7771 17321,7771 17321,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 4482,9733 L 5124,9733 5124,6046 4482,6046 4482,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 8976,9733 L 9618,9733 9618,7151 8976,7151 8976,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13469,9733 L 14111,9733 14111,7023 13469,7023 13469,9733 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17963,9733 L 18605,9733 18605,6884 17963,6884 17963,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 5124,9733 L 5766,9733 5766,3891 5124,3891 5124,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 9618,9733 L 10260,9733 10260,5578 9618,5578 9618,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14111,9733 L 14753,9733 14753,5073 14111,5073 14111,9733 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 18605,9733 L 19247,9733 19247,4733 18605,4733 18605,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 5766,9733 L 6408,9733 6408,1976 5766,1976 5766,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 10260,9733 L 10901,9733 10901,4189 10260,4189 10260,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 14753,9733 L 15395,9733 15395,3615 14753,3615 14753,9733 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 19247,9733 L 19889,9733 19889,2864 19247,2864 19247,9733 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4081" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8547" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13164" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17572" y="10301"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1794" y="9854"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="8634"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="7415"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="6196"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="4978"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="3759"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="2540"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1411" y="1321"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6291,576 L 6186,576 6186,365 6397,365 6397,576 6291,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7639,576 L 7534,576 7534,365 7745,365 7745,576 7639,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 8987,576 L 8882,576 8882,365 9093,365 9093,576 8987,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 10335,576 L 10230,576 10230,365 10440,365 10440,576 10335,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11683,576 L 11577,576 11577,365 11788,365 11788,576 11683,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 13222,576 L 13116,576 13116,365 13327,365 13327,576 13222,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="6497" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7845" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9193" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10540" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">6 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11888" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">12 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13427" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">24 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9409" y="11000"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 7985)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="7985"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-nas-1vm-model.svg
+++ b/images/src/svg/EPYC5-nas-1vm-model.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13286,14947 L -13,14947 -13,-13 26584,-13 26584,14947 13286,14947 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14203,14001 L 2354,14001 2354,1268 26053,1268 26053,14001 14203,14001 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,12408 L 2354,12408 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,10816 L 2354,10816 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,9224 L 2354,9224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,6042 L 2354,6042 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,4450 L 2354,4450 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,2858 L 2354,2858 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,1267 L 2354,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14150 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5739,14150 L 5739,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9125,14150 L 9125,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12511,14150 L 12511,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15895,14150 L 15895,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19281,14150 L 19281,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22667,14150 L 22667,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,14000 L 2354,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12408 L 2354,12408 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12408 L 2354,12408 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10816 L 2354,10816 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10816 L 2354,10816 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,9224 L 2354,9224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,9224 L 2354,9224 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7633 L 2354,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6042 L 2354,6042 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,6042 L 2354,6042 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,4450 L 2354,4450 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,4450 L 2354,4450 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2858 L 2354,2858 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,2858 L 2354,2858 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1267 L 2354,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1267 L 2354,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,14000 L 2354,1267 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2692,14000 L 3369,14000 3369,6722 2692,6722 2692,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6078,14000 L 6755,14000 6755,8686 6078,8686 6078,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9464,14000 L 10141,14000 10141,13762 9464,13762 9464,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12849,14000 L 13525,14000 13525,13863 12849,13863 12849,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16234,14000 L 16911,14000 16911,9044 16234,9044 16234,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 19620,14000 L 20297,14000 20297,13068 19620,13068 19620,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 23005,14000 L 23683,14000 23683,2882 23005,2882 23005,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3369,14000 L 4046,14000 4046,6722 3369,6722 3369,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 6755,14000 L 7432,14000 7432,8553 6755,8553 6755,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10141,14000 L 10818,14000 10818,13780 10141,13780 10141,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13525,14000 L 14202,14000 14202,13864 13525,13864 13525,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16911,14000 L 17588,14000 17588,9046 16911,9046 16911,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 20297,14000 L 20974,14000 20974,13066 20297,13066 20297,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 23683,14000 L 24360,14000 24360,2892 23683,2892 23683,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4046,14000 L 4724,14000 4724,6737 4046,6737 4046,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 7432,14000 L 8109,14000 8109,9699 7432,9699 7432,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10818,14000 L 11495,14000 11495,13750 10818,13750 10818,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14203,14000 L 14880,14000 14880,13864 14203,13864 14203,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17588,14000 L 18265,14000 18265,9049 17588,9049 17588,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 20974,14000 L 21651,14000 21651,13064 20974,13064 20974,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 24360,14000 L 25037,14000 25037,2994 24360,2994 24360,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 4724,14000 L 5401,14000 5401,6731 4724,6731 4724,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 8109,14000 L 8786,14000 8786,9594 8109,9594 8109,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 11495,14000 L 12172,14000 12172,13760 11495,13760 11495,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 14880,14000 L 15557,14000 15557,13864 14880,13864 14880,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 18265,14000 L 18943,14000 18943,9048 18265,9048 18265,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 21651,14000 L 22328,14000 22328,13064 21651,13064 21651,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 25037,14000 L 25714,14000 25714,3017 25037,3017 25037,14000 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3731" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7079" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10455" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13908" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17283" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20564" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24007" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1913" y="14121"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="12529"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="10937"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="9345"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="7754"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">80</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6163"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="4571"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">120</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="2979"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">140</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1388"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">160</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7254,576 L 7149,576 7149,365 7360,365 7360,576 7254,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9386,576 L 9281,576 9281,365 9492,365 9492,576 9386,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12713,576 L 12608,576 12608,365 12819,365 12819,576 12713,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 15591,576 L 15485,576 15485,365 15696,365 15696,576 15591,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7460" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre"> cpumodel</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9592" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpumodel+haltpoll</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12919" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthough</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15796" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthough+haltpoll</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8608)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8608"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13166" y="7610"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-nas-2vms-sev.svg
+++ b/images/src/svg/EPYC5-nas-2vms-sev.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="204mm" height="115mm" viewBox="0 0 20400 11500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 10188,11462 L -13,11462 -13,-13 20388,-13 20388,11462 10188,11462 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 11201,10586 L 2422,10586 2422,1198 19980,1198 19980,10586 11201,10586 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,10585 L 2422,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,9646 L 2422,9646 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,8707 L 2422,8707 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,7768 L 2422,7768 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,6829 L 2422,6829 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,5890 L 2422,5890 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,4952 L 2422,4952 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,4013 L 2422,4013 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,3074 L 2422,3074 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,2135 L 2422,2135 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,1197 L 2422,1197 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2422,10735 L 2422,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2422,10735 L 2422,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 4930,10735 L 4930,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 4930,10735 L 4930,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7438,10735 L 7438,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 7438,10735 L 7438,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9947,10735 L 9947,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9947,10735 L 9947,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12454,10735 L 12454,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12454,10735 L 12454,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14963,10735 L 14963,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14963,10735 L 14963,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17471,10735 L 17471,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 17471,10735 L 17471,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,10735 L 19980,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19980,10735 L 19980,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2422,10585 L 19980,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,10585 L 2422,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,10585 L 2422,10585 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,9646 L 2422,9646 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,9646 L 2422,9646 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,8707 L 2422,8707 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,8707 L 2422,8707 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,7768 L 2422,7768 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,7768 L 2422,7768 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,6829 L 2422,6829 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,6829 L 2422,6829 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,5890 L 2422,5890 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,5890 L 2422,5890 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,4952 L 2422,4952 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,4952 L 2422,4952 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,4013 L 2422,4013 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,4013 L 2422,4013 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,3074 L 2422,3074 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,3074 L 2422,3074 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,2135 L 2422,2135 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,2135 L 2422,2135 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,1197 L 2422,1197 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2272,1197 L 2422,1197 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2422,10585 L 2422,1197 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2735,10585 L 3362,10585 3362,6824 2735,6824 2735,10585 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 5243,10585 L 5871,10585 5871,9153 5243,9153 5243,10585 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7752,10585 L 8379,10585 8379,10483 7752,10483 7752,10585 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10259,10585 L 10886,10585 10886,10526 10259,10526 10259,10585 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12768,10585 L 13395,10585 13395,8409 12768,8409 12768,10585 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 15276,10585 L 15903,10585 15903,10161 15276,10161 15276,10585 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 17785,10585 L 18412,10585 18412,2357 17785,2357 17785,10585 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3362,10585 L 3989,10585 3989,6826 3362,6826 3362,10585 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 5871,10585 L 6498,10585 6498,9157 5871,9157 5871,10585 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 8379,10585 L 9006,10585 9006,10480 8379,10480 8379,10585 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10886,10585 L 11514,10585 11514,10528 10886,10528 10886,10585 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13395,10585 L 14022,10585 14022,8411 13395,8411 13395,10585 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15903,10585 L 16530,10585 16530,10163 15903,10163 15903,10585 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 18412,10585 L 19039,10585 19039,2351 18412,2351 18412,10585 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 3989,10585 L 4616,10585 4616,6822 3989,6822 3989,10585 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 6498,10585 L 7125,10585 7125,9153 6498,9153 6498,10585 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 9006,10585 L 9633,10585 9633,10482 9006,10482 9006,10585 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11514,10585 L 12141,10585 12141,10527 11514,10527 11514,10585 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 14022,10585 L 14649,10585 14649,8408 14022,8408 14022,10585 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 16530,10585 L 17158,10585 17158,10162 16530,10162 16530,10585 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 19039,10585 L 19666,10585 19666,2347 19039,2347 19039,10585 Z "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3049,6828 L 3049,6824 3049,6819 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3149,6828 L 2949,6828 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 2949,6819 L 3149,6819 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 5557,9167 L 5557,9153 5557,9139 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 5657,9167 L 5457,9167 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 5457,9139 L 5657,9139 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 8065,10486 L 8065,10483 8065,10480 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 8165,10486 L 7965,10486 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 7965,10480 L 8165,10480 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 10573,10527 L 10573,10526 10573,10525 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 10673,10527 L 10473,10527 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 10473,10525 L 10673,10525 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 13081,8410 L 13081,8409 13081,8409 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 13181,8410 L 12981,8410 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 12981,8409 L 13181,8409 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 15590,10162 L 15590,10161 15590,10160 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 15690,10162 L 15490,10162 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 15490,10160 L 15690,10160 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18098,2364 L 18098,2357 18098,2350 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18198,2364 L 17998,2364 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 17998,2350 L 18198,2350 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3676,6830 L 3676,6826 3676,6822 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3776,6830 L 3576,6830 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 3576,6822 L 3776,6822 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6184,9176 L 6184,9157 6184,9137 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6284,9176 L 6084,9176 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6084,9137 L 6284,9137 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 8693,10485 L 8693,10480 8693,10476 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 8793,10485 L 8593,10485 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 8593,10476 L 8793,10476 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11200,10529 L 11200,10528 11200,10526 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11300,10529 L 11100,10529 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11100,10526 L 11300,10526 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 13708,8412 L 13708,8411 13708,8409 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 13808,8412 L 13608,8412 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 13608,8409 L 13808,8409 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 16217,10163 L 16217,10163 16217,10162 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 16317,10163 L 16117,10163 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 16117,10162 L 16317,10162 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18725,2359 L 18725,2351 18725,2344 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18825,2359 L 18625,2359 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 18625,2344 L 18825,2344 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 4303,6829 L 4303,6822 4303,6815 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 4403,6829 L 4203,6829 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 4203,6815 L 4403,6815 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6811,9167 L 6811,9153 6811,9139 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6911,9167 L 6711,9167 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 6711,9139 L 6911,9139 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 9320,10486 L 9320,10482 9320,10477 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 9420,10486 L 9220,10486 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 9220,10477 L 9420,10477 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11827,10529 L 11827,10527 11827,10526 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11927,10529 L 11727,10529 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 11727,10526 L 11927,10526 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 14336,8411 L 14336,8408 14336,8405 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 14436,8411 L 14236,8411 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 14236,8405 L 14436,8405 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 16844,10162 L 16844,10162 16844,10161 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 16944,10162 L 16744,10162 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 16744,10161 L 16944,10161 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 19352,2349 L 19352,2347 19352,2344 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 19452,2349 L 19252,2349 "/>
+ <path fill="none" stroke="rgb(0,0,0)" stroke-linejoin="round" d="M 19252,2344 L 19452,2344 "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3361" y="11153"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="5831" y="11153"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8330" y="11153"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10905" y="11153"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13403" y="11153"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15807" y="11153"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="18372" y="11153"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1981" y="10706"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="9767"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="8828"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="7889"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="6950"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="6011"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="5073"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="4134"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="3195"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1598" y="2256"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">900</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1407" y="1318"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1000</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7670,576 L 7565,576 7565,365 7776,365 7776,576 7670,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10108,576 L 10003,576 10003,365 10213,365 10213,576 10108,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11341,576 L 11235,576 11235,365 11446,365 11446,576 11341,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7876" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">unencrypted</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10313" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11546" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">SEV-ES</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 6865)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="6865"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10068" y="5868"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-nas-bm-16vm.svg
+++ b/images/src/svg/EPYC5-nas-bm-16vm.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13286,14947 L -13,14947 -13,-13 26584,-13 26584,14947 13286,14947 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14299,14001 L 2545,14001 2545,1269 26053,1269 26053,14001 14299,14001 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14000 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,12408 L 2545,12408 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,10816 L 2545,10816 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,9225 L 2545,9225 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,7633 L 2545,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,6042 L 2545,6042 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,4451 L 2545,4451 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,2859 L 2545,2859 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,1268 L 2545,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14150 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14150 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5903,14150 L 5903,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5903,14150 L 5903,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9261,14150 L 9261,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9261,14150 L 9261,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12620,14150 L 12620,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 12620,14150 L 12620,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15977,14150 L 15977,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15977,14150 L 15977,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19336,14150 L 19336,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19336,14150 L 19336,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22694,14150 L 22694,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 22694,14150 L 22694,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26053,14150 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14000 L 26053,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,14000 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,14000 L 2545,14000 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,12408 L 2545,12408 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,12408 L 2545,12408 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,10816 L 2545,10816 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,10816 L 2545,10816 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,9225 L 2545,9225 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,9225 L 2545,9225 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,7633 L 2545,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,7633 L 2545,7633 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,6042 L 2545,6042 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,6042 L 2545,6042 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,4451 L 2545,4451 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,4451 L 2545,4451 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,2859 L 2545,2859 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,2859 L 2545,2859 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,1268 L 2545,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2395,1268 L 2545,1268 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2545,14000 L 2545,1268 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2784,14000 L 3264,14000 3264,13710 2784,13710 2784,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6143,14000 L 6623,14000 6623,13778 6143,13778 6143,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9501,14000 L 9981,14000 9981,13990 9501,13990 9501,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12860,14000 L 13338,14000 13338,13994 12860,13994 12860,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 16217,14000 L 16697,14000 16697,13801 16217,13801 16217,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 19576,14000 L 20055,14000 20055,13962 19576,13962 19576,14000 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 22934,14000 L 23414,14000 23414,13557 22934,13557 22934,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3264,14000 L 3744,14000 3744,13708 3264,13708 3264,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 6623,14000 L 7102,14000 7102,13782 6623,13782 6623,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9981,14000 L 10461,14000 10461,13991 9981,13991 9981,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 13338,14000 L 13818,14000 13818,13994 13338,13994 13338,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 16697,14000 L 17177,14000 17177,13801 16697,13801 16697,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 20055,14000 L 20535,14000 20535,13962 20055,13962 20055,14000 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 23414,14000 L 23894,14000 23894,13555 23414,13555 23414,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 3744,14000 L 4224,14000 4224,13407 3744,13407 3744,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 7102,14000 L 7582,14000 7582,13713 7102,13713 7102,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10461,14000 L 10941,14000 10941,13981 10461,13981 10461,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 13818,14000 L 14298,14000 14298,13990 13818,13990 13818,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17177,14000 L 17656,14000 17656,13599 17177,13599 17177,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 20535,14000 L 21015,14000 21015,13927 20535,13927 20535,14000 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 23894,14000 L 24373,14000 24373,12866 23894,12866 23894,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 4224,14000 L 4703,14000 4703,12725 4224,12725 4224,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 7582,14000 L 8062,14000 8062,13514 7582,13514 7582,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 10941,14000 L 11420,14000 11420,13965 10941,13965 10941,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 14298,14000 L 14778,14000 14778,13980 14298,13980 14298,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17656,14000 L 18136,14000 18136,13262 17656,13262 17656,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 21015,14000 L 21495,14000 21495,13856 21015,13856 21015,14000 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 24373,14000 L 24853,14000 24853,11210 24373,11210 24373,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 4703,14000 L 5183,14000 5183,11363 4703,11363 4703,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 8062,14000 L 8542,14000 8542,13154 8062,13154 8062,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11420,14000 L 11900,14000 11900,13930 11420,13930 11420,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14778,14000 L 15258,14000 15258,13954 14778,13954 14778,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 18136,14000 L 18616,14000 18616,12314 18136,12314 18136,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 21495,14000 L 21974,14000 21974,13655 21495,13655 21495,14000 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 24853,14000 L 25333,14000 25333,8198 24853,8198 24853,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 5183,14000 L 5663,14000 5663,8966 5183,8966 5183,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 8542,14000 L 9021,14000 9021,12335 8542,12335 8542,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 11900,14000 L 12380,14000 12380,13864 11900,13864 11900,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 15258,14000 L 15737,14000 15737,13928 15258,13928 15258,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 18616,14000 L 19096,14000 19096,9544 18616,9544 18616,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 21974,14000 L 22454,14000 22454,13289 21974,13289 21974,14000 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 25333,14000 L 25813,14000 25813,2392 25333,2392 25333,14000 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3909" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7229" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10578" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14003" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17351" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="20605" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24020" y="14568"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="2104" y="14121"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1721" y="12529"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="10937"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1000</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="9346"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="7754"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2000</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6163"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="4572"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">3000</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="2980"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">3500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1389"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4000</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8727,576 L 8622,576 8622,365 8833,365 8833,576 8727,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 11355,576 L 11250,576 11250,365 11461,365 11461,576 11355,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12703,576 L 12598,576 12598,365 12809,365 12809,576 12703,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 14051,576 L 13945,576 13945,365 14156,365 14156,576 14051,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 15399,576 L 15293,576 15293,365 15504,365 15504,576 15399,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 16747,576 L 16641,576 16641,365 16852,365 16852,576 16747,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8933" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BAREMETAL</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11561" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12909" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14256" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15604" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">8 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16952" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">16 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8608)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8608"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13166" y="7610"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-nas-bm-1vm.svg
+++ b/images/src/svg/EPYC5-nas-bm-1vm.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="282mm" height="159mm" viewBox="0 0 28200 15900" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 14088,15849 L -13,15849 -13,-13 28188,-13 28188,15849 14088,15849 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15005,14885 L 2387,14885 2387,1286 27624,1286 27624,14885 15005,14885 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,14884 L 2387,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,13184 L 2387,13184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,11484 L 2387,11484 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,9784 L 2387,9784 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,8084 L 2387,8084 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,6385 L 2387,6385 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,4685 L 2387,4685 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,2985 L 2387,2985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,1285 L 2387,1285 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2387,15034 L 2387,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2387,15034 L 2387,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5992,15034 L 5992,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 5992,15034 L 5992,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9597,15034 L 9597,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 9597,15034 L 9597,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13203,15034 L 13203,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13203,15034 L 13203,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 16807,15034 L 16807,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 16807,15034 L 16807,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20413,15034 L 20413,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20413,15034 L 20413,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24018,15034 L 24018,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24018,15034 L 24018,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,15034 L 27624,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 27624,15034 L 27624,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2387,14884 L 27624,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,14884 L 2387,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,14884 L 2387,14884 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,13184 L 2387,13184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,13184 L 2387,13184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,11484 L 2387,11484 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,11484 L 2387,11484 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,9784 L 2387,9784 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,9784 L 2387,9784 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,8084 L 2387,8084 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,8084 L 2387,8084 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,6385 L 2387,6385 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,6385 L 2387,6385 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,4685 L 2387,4685 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,4685 L 2387,4685 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,2985 L 2387,2985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,2985 L 2387,2985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,1285 L 2387,1285 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2237,1285 L 2387,1285 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2387,14884 L 2387,1285 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2987,14884 L 4189,14884 4189,7154 2987,7154 2987,14884 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6593,14884 L 7795,14884 7795,8979 6593,8979 6593,14884 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 10198,14884 L 11400,14884 11400,14638 10198,14638 10198,14884 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 13804,14884 L 15005,14884 15005,14740 13804,14740 13804,14884 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 17408,14884 L 18610,14884 18610,9591 17408,9591 17408,14884 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 21014,14884 L 22215,14884 22215,13892 21014,13892 21014,14884 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 24619,14884 L 25821,14884 25821,3079 24619,3079 24619,14884 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4189,14884 L 5391,14884 5391,7111 4189,7111 4189,14884 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 7795,14884 L 8996,14884 8996,9067 7795,9067 7795,14884 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 11400,14884 L 12602,14884 12602,14649 11400,14649 11400,14884 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15005,14884 L 16206,14884 16206,14739 15005,14739 15005,14884 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 18610,14884 L 19812,14884 19812,9593 18610,9593 18610,14884 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 22215,14884 L 23417,14884 23417,13886 22215,13886 22215,14884 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 25821,14884 L 27023,14884 27023,3021 25821,3021 25821,14884 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3874" y="15452"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">bt.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7442" y="15452"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11037" y="15452"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">ep.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14710" y="15452"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">is.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="18305" y="15452"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">lu.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="21805" y="15452"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">mg.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="25468" y="15452"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">sp.D</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1946" y="15005"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1754" y="13305"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1754" y="11605"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1754" y="9905"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1754" y="8205"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">80</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1563" y="6506"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1563" y="4806"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">120</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1563" y="3106"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">140</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1563" y="1406"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">160</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 12321,576 L 12216,576 12216,365 12427,365 12427,576 12321,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 14949,576 L 14843,576 14843,365 15054,365 15054,576 14949,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12527" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BAREMETAL</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15154" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9059)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9059"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Time (sec)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13968" y="8061"><tspan font-family="Liberation Serif, serif" font-size="423px" font-weight="400" fill="rgb(255,255,255)" stroke="none" style="white-space: pre">=</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-stream-bm-1vm.svg
+++ b/images/src/svg/EPYC5-stream-bm-1vm.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="288mm" height="150mm" viewBox="0 0 28800 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 14411,14968 L -13,14968 -13,-13 28834,-13 28834,14968 14411,14968 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15328,13041 L 2399,13041 2399,1268 28258,1268 28258,13041 15328,13041 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,13040 L 2399,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,11568 L 2399,11568 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,10096 L 2399,10096 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,8624 L 2399,8624 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,7154 L 2399,7154 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,5682 L 2399,5682 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,4210 L 2399,4210 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,2738 L 2399,2738 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,1267 L 2399,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2399,13190 L 2399,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2399,13190 L 2399,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8864,13190 L 8864,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8864,13190 L 8864,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15328,13190 L 15328,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 15328,13190 L 15328,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 21793,13190 L 21793,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 21793,13190 L 21793,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,13190 L 28258,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 28258,13190 L 28258,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2399,13040 L 28258,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,13040 L 2399,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,13040 L 2399,13040 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,11568 L 2399,11568 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,11568 L 2399,11568 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,10096 L 2399,10096 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,10096 L 2399,10096 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,8624 L 2399,8624 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,8624 L 2399,8624 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,7154 L 2399,7154 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,7154 L 2399,7154 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,5682 L 2399,5682 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,5682 L 2399,5682 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,4210 L 2399,4210 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,4210 L 2399,4210 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,2738 L 2399,2738 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,2738 L 2399,2738 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,1267 L 2399,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2249,1267 L 2399,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2399,13040 L 2399,1267 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 3045,13040 L 4338,13040 4338,12329 3045,12329 3045,13040 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9510,13040 L 10803,13040 10803,12447 9510,12447 9510,13040 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 15974,13040 L 17267,13040 17267,12430 15974,12430 15974,13040 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 22439,13040 L 23732,13040 23732,12432 22439,12432 22439,13040 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 4338,13040 L 5631,13040 5631,12327 4338,12327 4338,13040 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10803,13040 L 12096,13040 12096,12445 10803,12445 10803,13040 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 17267,13040 L 18560,13040 18560,12429 17267,12429 17267,13040 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 23732,13040 L 25025,13040 25025,12431 23732,12431 23732,13040 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 5631,13040 L 6924,13040 6924,3005 5631,3005 5631,13040 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12096,13040 L 13389,13040 13389,5896 12096,5896 12096,13040 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 18560,13040 L 19853,13040 19853,5108 18560,5108 18560,13040 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 25025,13040 L 26318,13040 26318,5005 25025,5005 25025,13040 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 6924,13040 L 8217,13040 8217,3014 6924,3014 6924,13040 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13389,13040 L 14681,13040 14681,5946 13389,5946 13389,13040 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 19853,13040 L 21146,13040 21146,5155 19853,5155 19853,13040 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 26318,13040 L 27611,13040 27611,5072 26318,5072 26318,13040 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="5230" y="13608"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11667" y="13608"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="18255" y="13608"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="24634" y="13608"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1958" y="13161"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="11689"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="10217"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="8745"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="7275"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="5803"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="4331"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="2859"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1575" y="1388"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 6382,576 L 6277,576 6277,365 6488,365 6488,576 6382,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 8533,576 L 8428,576 8428,365 8639,365 8639,576 8533,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10971,576 L 10866,576 10866,365 11077,365 11077,576 10971,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 16783,576 L 16677,576 16677,365 16888,365 16888,576 16783,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="6588" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BM, single</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8739" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM, single</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11177" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">BM, openmp (2xLLCs threads=64)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16988" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM, openmp (2xLLCs threads=64)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13514" y="14374"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9081)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9081"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Bandwidth (GBytes/sec)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-stream-omp-1vm-model.svg
+++ b/images/src/svg/EPYC5-stream-omp-1vm-model.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="266mm" height="149mm" viewBox="0 0 26600 14900" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13262,14919 L -13,14919 -13,-13 26536,-13 26536,14919 13262,14919 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14179,12993 L 2354,12993 2354,1765 26005,1765 26005,12993 14179,12993 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,12992 L 2354,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,11588 L 2354,11588 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,10184 L 2354,10184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,8781 L 2354,8781 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,7378 L 2354,7378 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,5974 L 2354,5974 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,4571 L 2354,4571 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,3167 L 2354,3167 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,1764 L 2354,1764 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,13142 L 2354,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,13142 L 2354,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8267,13142 L 8267,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8267,13142 L 8267,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14179,13142 L 14179,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14179,13142 L 14179,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20092,13142 L 20092,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20092,13142 L 20092,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,13142 L 26005,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26005,13142 L 26005,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,12992 L 26005,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12992 L 2354,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,12992 L 2354,12992 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11588 L 2354,11588 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,11588 L 2354,11588 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10184 L 2354,10184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,10184 L 2354,10184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8781 L 2354,8781 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,8781 L 2354,8781 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7378 L 2354,7378 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,7378 L 2354,7378 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5974 L 2354,5974 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,5974 L 2354,5974 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,4571 L 2354,4571 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,4571 L 2354,4571 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3167 L 2354,3167 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,3167 L 2354,3167 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1764 L 2354,1764 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2204,1764 L 2354,1764 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2354,12992 L 2354,1764 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2776,12992 L 3621,12992 3621,3452 2776,3452 2776,12992 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8689,12992 L 9534,12992 9534,6250 8689,6250 8689,12992 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 14601,12992 L 15446,12992 15446,5494 14601,5494 14601,12992 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 20514,12992 L 21359,12992 21359,5418 20514,5418 20514,12992 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3621,12992 L 4465,12992 4465,3430 3621,3430 3621,12992 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9534,12992 L 10378,12992 10378,6227 9534,6227 9534,12992 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15446,12992 L 16290,12992 16290,5472 15446,5472 15446,12992 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 21359,12992 L 22203,12992 22203,5393 21359,5393 21359,12992 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4465,12992 L 5310,12992 5310,10483 4465,10483 4465,12992 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10378,12992 L 11223,12992 11223,10823 10378,10823 10378,12992 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 16290,12992 L 17135,12992 17135,10769 16290,10769 16290,12992 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 22203,12992 L 23048,12992 23048,10772 22203,10772 22203,12992 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 5310,12992 L 6155,12992 6155,10482 5310,10482 5310,12992 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 11223,12992 L 12068,12992 12068,10816 11223,10816 11223,12992 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17135,12992 L 17980,12992 17980,10756 17135,10756 17135,12992 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 23048,12992 L 23893,12992 23893,10770 23048,10770 23048,12992 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 6155,12992 L 6999,12992 6999,3503 6155,3503 6155,12992 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 12068,12992 L 12912,12992 12912,6194 12068,6194 12068,12992 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 17980,12992 L 18824,12992 18824,5464 17980,5464 17980,12992 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 23893,12992 L 24737,12992 24737,5375 23893,5375 23893,12992 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 6999,12992 L 7844,12992 7844,3462 6999,3462 6999,12992 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 12912,12992 L 13756,12992 13756,6209 12912,6209 12912,12992 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 18824,12992 L 19669,12992 19669,5467 18824,5467 18824,12992 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 24737,12992 L 25582,12992 25582,5376 24737,5376 24737,12992 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4880" y="13560"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">178.7</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10698" y="13560"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">154.51</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16610" y="13560"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">158.33</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="22523" y="13560"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">158.16</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1913" y="13113"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="11709"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="10305"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="8902"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="7499"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="6095"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="4692"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="3288"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1885"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 3396,576 L 3291,576 3291,365 3502,365 3502,576 3396,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10691,576 L 10586,576 10586,365 10797,365 10797,576 10691,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17335,576 L 17229,576 17229,365 17440,365 17440,576 17335,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 3396,1074 L 3291,1074 3291,863 3502,863 3502,1074 3396,1074 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 10691,1074 L 10586,1074 10586,863 10797,863 10797,1074 10691,1074 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 17335,1074 L 17229,1074 17229,863 17440,863 17440,1074 17335,1074 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3602" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre"> cpumodel  (2xLLCs threads=64)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10897" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpumodel+haltpoll (2xLLCs threads=64)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17540" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthough (2xLLCs=4 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="3602" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthough+haltpoll (2xLLCs=4 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10897" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough (64 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17540" y="1088"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough+haltpoll (64 threads)</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12365" y="14325"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8414)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8414"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-stream-omp-vms-avg.svg
+++ b/images/src/svg/EPYC5-stream-omp-vms-avg.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="275mm" height="155mm" viewBox="0 0 27500 15500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13740,15457 L -13,15457 -13,-13 27492,-13 27492,15457 13740,15457 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14657,13520 L 2373,13520 2373,1278 26942,1278 26942,13520 14657,13520 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,13519 L 2373,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,11988 L 2373,11988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,10458 L 2373,10458 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,8927 L 2373,8927 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,7398 L 2373,7398 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,5868 L 2373,5868 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,4337 L 2373,4337 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,2807 L 2373,2807 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,1277 L 2373,1277 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,13669 L 2373,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,13669 L 2373,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8515,13669 L 8515,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8515,13669 L 8515,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14657,13669 L 14657,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14657,13669 L 14657,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20799,13669 L 20799,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20799,13669 L 20799,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,13669 L 26942,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26942,13669 L 26942,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,13519 L 26942,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,13519 L 2373,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,13519 L 2373,13519 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,11988 L 2373,11988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,11988 L 2373,11988 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,10458 L 2373,10458 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,10458 L 2373,10458 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,8927 L 2373,8927 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,8927 L 2373,8927 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,7398 L 2373,7398 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,7398 L 2373,7398 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,5868 L 2373,5868 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,5868 L 2373,5868 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,4337 L 2373,4337 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,4337 L 2373,4337 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,2807 L 2373,2807 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,2807 L 2373,2807 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,1277 L 2373,1277 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2223,1277 L 2373,1277 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,13519 L 2373,1277 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2811,13519 L 3689,13519 3689,3094 2811,3094 2811,13519 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8954,13519 L 9831,13519 9831,6143 8954,6143 8954,13519 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 15095,13519 L 15973,13519 15973,5320 15095,5320 15095,13519 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 21238,13519 L 22115,13519 22115,5233 21238,5233 21238,13519 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3689,13519 L 4566,13519 4566,8312 3689,8312 3689,13519 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9831,13519 L 10709,13519 10709,9888 9831,9888 9831,13519 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15973,13519 L 16850,13519 16850,9456 15973,9456 15973,13519 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 22115,13519 L 22993,13519 22993,9430 22115,9430 22115,13519 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4566,13519 L 5444,13519 5444,10643 4566,10643 4566,13519 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10709,13519 L 11586,13519 11586,11713 10709,11713 10709,13519 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 16850,13519 L 17728,13519 17728,11463 16850,11463 16850,13519 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 22993,13519 L 23870,13519 23870,11408 22993,11408 22993,13519 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 5444,13519 L 6321,13519 6321,12061 5444,12061 5444,13519 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 11586,13519 L 12464,13519 12464,12622 11586,12622 11586,13519 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17728,13519 L 18605,13519 18605,12490 17728,12490 17728,13519 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 23870,13519 L 24748,13519 24748,12442 23870,12442 23870,13519 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 6321,13519 L 7199,13519 7199,12716 6321,12716 6321,13519 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 12464,13519 L 13341,13519 13341,13074 12464,13074 12464,13519 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 18605,13519 L 19483,13519 19483,13003 18605,13003 18605,13519 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 24748,13519 L 25625,13519 25625,12936 24748,12936 24748,13519 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 7199,13519 L 8076,13519 8076,13101 7199,13101 7199,13519 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 13341,13519 L 14218,13519 14218,13298 13341,13298 13341,13519 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 19483,13519 L 20360,13519 20360,13258 19483,13258 19483,13519 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 25625,13519 L 26503,13519 26503,13225 25625,13225 25625,13519 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="5043" y="14087"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11157" y="14087"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17423" y="14087"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="23479" y="14087"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1932" y="13640"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="12109"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="10579"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="9048"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="7519"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="5989"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="4458"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="2928"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1549" y="1398"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9726,576 L 9621,576 9621,365 9832,365 9832,576 9726,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 11074,576 L 10969,576 10969,365 11180,365 11180,576 11074,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12422,576 L 12317,576 12317,365 12528,365 12528,576 12422,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13770,576 L 13665,576 13665,365 13875,365 13875,576 13770,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 15118,576 L 15012,576 15012,365 15223,365 15223,576 15118,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 16657,576 L 16551,576 16551,365 16762,365 16762,576 16657,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9932" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11280" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12628" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13975" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">8 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15323" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">16 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16862" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">32 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12843" y="14863"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9916)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9916"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-stream-omp-vms-sum.svg
+++ b/images/src/svg/EPYC5-stream-omp-vms-sum.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="255mm" height="143mm" viewBox="0 0 25500 14300" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 12722,14312 L -13,14312 -13,-13 25456,-13 25456,14312 12722,14312 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13735,12398 L 2523,12398 2523,1255 24947,1255 24947,12398 13735,12398 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,12397 L 2523,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,11282 L 2523,11282 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,10168 L 2523,10168 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,9053 L 2523,9053 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,7939 L 2523,7939 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,6826 L 2523,6826 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,5711 L 2523,5711 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,4597 L 2523,4597 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,3482 L 2523,3482 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,2368 L 2523,2368 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,1254 L 2523,1254 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2523,12547 L 2523,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2523,12547 L 2523,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8129,12547 L 8129,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8129,12547 L 8129,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13734,12547 L 13734,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 13734,12547 L 13734,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19340,12547 L 19340,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 19340,12547 L 19340,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,12547 L 24947,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 24947,12547 L 24947,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2523,12397 L 24947,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,12397 L 2523,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,12397 L 2523,12397 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,11282 L 2523,11282 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,11282 L 2523,11282 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,10168 L 2523,10168 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,10168 L 2523,10168 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,9053 L 2523,9053 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,9053 L 2523,9053 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,7939 L 2523,7939 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,7939 L 2523,7939 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,6826 L 2523,6826 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,6826 L 2523,6826 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,5711 L 2523,5711 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,5711 L 2523,5711 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,4597 L 2523,4597 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,4597 L 2523,4597 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,3482 L 2523,3482 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,3482 L 2523,3482 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,2368 L 2523,2368 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,2368 L 2523,2368 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,1254 L 2523,1254 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2373,1254 L 2523,1254 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2523,12397 L 2523,1254 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2923,12397 L 3724,12397 3724,4805 2923,4805 2923,12397 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8529,12397 L 9330,12397 9330,7026 8529,7026 8529,12397 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 14134,12397 L 14935,12397 14935,6427 14134,6427 14134,12397 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 19741,12397 L 20542,12397 20542,6364 19741,6364 19741,12397 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3724,12397 L 4525,12397 4525,4815 3724,4815 3724,12397 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9330,12397 L 10131,12397 10131,7110 9330,7110 9330,12397 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 14935,12397 L 15736,12397 15736,6481 14935,6481 14935,12397 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 20542,12397 L 21342,12397 21342,6443 20542,6443 20542,12397 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4525,12397 L 5326,12397 5326,4023 4525,4023 4525,12397 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10131,12397 L 10932,12397 10932,7138 10131,7138 10131,12397 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 15736,12397 L 16537,12397 16537,6411 15736,6411 15736,12397 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 21342,12397 L 22143,12397 22143,6250 21342,6250 21342,12397 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 5326,12397 L 6127,12397 6127,3906 5326,3906 5326,12397 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 10932,12397 L 11733,12397 11733,7175 10932,7175 10932,12397 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 16537,12397 L 17338,12397 17338,6407 16537,6407 16537,12397 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 22143,12397 L 22944,12397 22944,6129 22143,6129 22143,12397 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 6127,12397 L 6927,12397 6927,3050 6127,3050 6127,12397 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 11733,12397 L 12534,12397 12534,7216 11733,7216 11733,12397 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 17338,12397 L 18139,12397 18139,6394 17338,6394 17338,12397 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 22944,12397 L 23745,12397 23745,5609 22944,5609 22944,12397 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 6927,12397 L 7728,12397 7728,2668 6927,2668 6927,12397 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 12534,12397 L 13334,12397 13334,7258 12534,7258 12534,12397 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 18139,12397 L 18940,12397 18940,6327 18139,6327 18139,12397 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 23745,12397 L 24546,12397 24546,5553 23745,5553 23745,12397 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4925" y="12965"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10503" y="12965"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16232" y="12965"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="21752" y="12965"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="2082" y="12518"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="11403"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="10289"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="9174"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="8060"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="6947"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="5832"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="4718"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="3603"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1699" y="2489"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">900</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1508" y="1375"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1000</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8708,576 L 8603,576 8603,365 8814,365 8814,576 8708,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10056,576 L 9951,576 9951,365 10162,365 10162,576 10056,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11404,576 L 11299,576 11299,365 11510,365 11510,576 11404,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 12752,576 L 12647,576 12647,365 12857,365 12857,576 12752,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14100,576 L 13994,576 13994,365 14205,365 14205,576 14100,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 15639,576 L 15533,576 15533,365 15744,365 15744,576 15639,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="8914" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10262" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11610" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12957" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">8 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14305" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">16 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15844" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">32 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11825" y="13718"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9344)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9344"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-stream-single-1vm-model.svg
+++ b/images/src/svg/EPYC5-stream-single-1vm-model.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="266mm" height="150mm" viewBox="0 0 26600 15000" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13284,14945 L -13,14945 -13,-13 26581,-13 26581,14945 13284,14945 Z "/>
+ <path fill="rgb(255,255,255)" stroke="none" d="M 14106,13018 L 2163,13018 2163,1268 26050,1268 26050,13018 14106,13018 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14106,13018 L 2163,13018 2163,1268 26050,1268 26050,13018 14106,13018 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,13017 L 2163,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,11058 L 2163,11058 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,9100 L 2163,9100 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,7142 L 2163,7142 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,5184 L 2163,5184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,3225 L 2163,3225 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,1267 L 2163,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2163,13167 L 2163,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2163,13167 L 2163,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8134,13167 L 8134,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8134,13167 L 8134,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14105,13167 L 14105,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14105,13167 L 14105,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20077,13167 L 20077,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20077,13167 L 20077,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,13167 L 26049,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26049,13167 L 26049,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2163,13017 L 26049,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,13017 L 2163,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,13017 L 2163,13017 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,11058 L 2163,11058 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,11058 L 2163,11058 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,9100 L 2163,9100 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,9100 L 2163,9100 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,7142 L 2163,7142 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,7142 L 2163,7142 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,5184 L 2163,5184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,5184 L 2163,5184 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,3225 L 2163,3225 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,3225 L 2163,3225 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,1267 L 2163,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2013,1267 L 2163,1267 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2163,13017 L 2163,1267 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2760,13017 L 3954,13017 3954,3568 2760,3568 2760,13017 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8732,13017 L 9926,13017 9926,5127 8732,5127 8732,13017 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 14703,13017 L 15897,13017 15897,4900 14703,4900 14703,13017 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 20675,13017 L 21869,13017 21869,4931 20675,4931 20675,13017 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3954,13017 L 5149,13017 5149,3542 3954,3542 3954,13017 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9926,13017 L 11121,13017 11121,5109 9926,5109 9926,13017 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15897,13017 L 17091,13017 17091,4894 15897,4894 15897,13017 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 21869,13017 L 23063,13017 23063,4915 21869,4915 21869,13017 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 5148,13017 L 6343,13017 6343,3554 5148,3554 5148,13017 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11121,13017 L 12315,13017 12315,5123 11121,5123 11121,13017 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 17091,13017 L 18286,13017 18286,4900 17091,4900 17091,13017 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 23063,13017 L 24258,13017 24258,4921 23063,4921 23063,13017 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 6343,13017 L 7537,13017 7537,3593 6343,3593 6343,13017 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 12315,13017 L 13508,13017 13508,5152 12315,5152 12315,13017 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 18286,13017 L 19480,13017 19480,4929 18286,4929 18286,13017 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 24258,13017 L 25452,13017 25452,4962 24258,4962 24258,13017 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4748" y="13585"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10691" y="13585"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16787" y="13585"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="22672" y="13585"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1722" y="13138"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="11179"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">10</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="9221"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="7263"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">30</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="5305"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="3346"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1530" y="1388"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 7137,576 L 7032,576 7032,365 7243,365 7243,576 7137,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9269,576 L 9164,576 9164,365 9375,365 9375,576 9269,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12596,576 L 12491,576 12491,365 12702,365 12702,576 12596,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 15589,576 L 15483,576 15483,365 15694,365 15694,576 15589,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="7343" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre"> cpumodel</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9475" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpumodel+haltpoll</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12802" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15794" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">cpupassthrough+haltpoll</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12388" y="14351"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 8178)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="8178"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-stream-single-vms-avg.svg
+++ b/images/src/svg/EPYC5-stream-single-vms-avg.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="273mm" height="154mm" viewBox="0 0 27300 15400" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13646,15353 L -13,15353 -13,-13 27305,-13 27305,15353 13646,15353 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14468,13418 L 2178,13418 2178,1276 26759,1276 26759,13418 14468,13418 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,13417 L 2178,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,11393 L 2178,11393 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,9369 L 2178,9369 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,7346 L 2178,7346 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,5322 L 2178,5322 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,3298 L 2178,3298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,1275 L 2178,1275 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2178,13567 L 2178,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2178,13567 L 2178,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8323,13567 L 8323,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8323,13567 L 8323,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14468,13567 L 14468,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14468,13567 L 14468,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20613,13567 L 20613,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20613,13567 L 20613,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,13567 L 26759,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 26759,13567 L 26759,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2178,13417 L 26759,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,13417 L 2178,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,13417 L 2178,13417 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,11393 L 2178,11393 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,11393 L 2178,11393 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,9369 L 2178,9369 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,9369 L 2178,9369 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,7346 L 2178,7346 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,7346 L 2178,7346 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,5322 L 2178,5322 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,5322 L 2178,5322 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,3298 L 2178,3298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,3298 L 2178,3298 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,1275 L 2178,1275 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2028,1275 L 2178,1275 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2178,13417 L 2178,1275 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2616,13417 L 3494,13417 3494,3626 2616,3626 2616,13417 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8762,13417 L 9640,13417 9640,5245 8762,5245 8762,13417 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 14906,13417 L 15784,13417 15784,5023 14906,5023 14906,13417 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 21052,13417 L 21930,13417 21930,5045 21052,5045 21052,13417 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3494,13417 L 4372,13417 4372,3626 3494,3626 3494,13417 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9640,13417 L 10518,13417 10518,5242 9640,5242 9640,13417 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15784,13417 L 16662,13417 16662,5006 15784,5006 15784,13417 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 21930,13417 L 22808,13417 22808,5033 21930,5033 21930,13417 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4372,13417 L 5250,13417 5250,4200 4372,4200 4372,13417 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10518,13417 L 11396,13417 11396,5589 10518,5589 10518,13417 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 16662,13417 L 17540,13417 17540,5345 16662,5345 16662,13417 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 22808,13417 L 23686,13417 23686,5332 22808,5332 22808,13417 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 5250,13417 L 6128,13417 6128,5267 5250,5267 5250,13417 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 11396,13417 L 12274,13417 12274,6382 11396,6382 11396,13417 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17540,13417 L 18418,13417 18418,5918 17540,5918 17540,13417 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 23686,13417 L 24564,13417 24564,5862 23686,5862 23686,13417 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 6128,13417 L 7006,13417 7006,7072 6128,7072 6128,13417 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 12274,13417 L 13152,13417 13152,7982 12274,7982 12274,13417 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 18418,13417 L 19296,13417 19296,7495 18418,7495 18418,13417 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 24564,13417 L 25442,13417 25442,7302 24564,7302 24564,13417 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 7006,13417 L 7884,13417 7884,8934 7006,8934 7006,13417 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 13152,13417 L 14029,13417 14029,10411 13152,10411 13152,13417 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 19296,13417 L 20174,13417 20174,9987 19296,9987 19296,13417 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 25442,13417 L 26320,13417 26320,9712 25442,9712 25442,13417 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4849" y="13985"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10967" y="13985"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="17235" y="13985"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="23295" y="13985"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1737" y="13538"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1545" y="11514"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">10</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1545" y="9490"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">20</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1545" y="7467"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">30</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1545" y="5443"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">40</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1545" y="3419"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">50</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1545" y="1396"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">60</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9632,576 L 9527,576 9527,365 9738,365 9738,576 9632,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10980,576 L 10875,576 10875,365 11086,365 11086,576 10980,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 12328,576 L 12223,576 12223,365 12434,365 12434,576 12328,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13676,576 L 13571,576 13571,365 13781,365 13781,576 13676,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 15024,576 L 14918,576 14918,365 15129,365 15129,576 15024,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 16563,576 L 16457,576 16457,365 16668,365 16668,576 16563,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9838" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="11186" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12534" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13882" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">8 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="15229" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">16 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16768" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">32 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12750" y="14759"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9864)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9864"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/images/src/svg/EPYC5-stream-single-vms-sum.svg
+++ b/images/src/svg/EPYC5-stream-single-vms-sum.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="265mm" height="149mm" viewBox="0 0 26500 14900" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-width="28.222" stroke-linejoin="round" xml:space="preserve">
+ <path fill="rgb(255,255,255)" stroke="none" d="M 13255,14912 L -13,14912 -13,-13 26523,-13 26523,14912 13255,14912 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14173,12986 L 2353,12986 2353,1267 25993,1267 25993,12986 14173,12986 Z "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,12985 L 2353,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,11520 L 2353,11520 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,10055 L 2353,10055 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,8590 L 2353,8590 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,7126 L 2353,7126 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,5661 L 2353,5661 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,4196 L 2353,4196 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,2731 L 2353,2731 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,1266 L 2353,1266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,13135 L 2353,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,13135 L 2353,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8263,13135 L 8263,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 8263,13135 L 8263,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14172,13135 L 14172,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 14172,13135 L 14172,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20082,13135 L 20082,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 20082,13135 L 20082,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,13135 L 25993,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 25993,13135 L 25993,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,12985 L 25993,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,12985 L 2353,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,12985 L 2353,12985 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,11520 L 2353,11520 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,11520 L 2353,11520 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,10055 L 2353,10055 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,10055 L 2353,10055 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,8590 L 2353,8590 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,8590 L 2353,8590 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,7126 L 2353,7126 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,7126 L 2353,7126 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,5661 L 2353,5661 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,5661 L 2353,5661 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,4196 L 2353,4196 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,4196 L 2353,4196 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,2731 L 2353,2731 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,2731 L 2353,2731 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,1266 L 2353,1266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2203,1266 L 2353,1266 "/>
+ <path fill="none" stroke="rgb(179,179,179)" stroke-linejoin="round" d="M 2353,12985 L 2353,1266 "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 2775,12985 L 3619,12985 3619,12276 2775,12276 2775,12985 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 8685,12985 L 9529,12985 9529,12393 8685,12393 8685,12985 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 14594,12985 L 15438,12985 15438,12377 14594,12377 14594,12985 Z "/>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 20504,12985 L 21349,12985 21349,12378 20504,12378 20504,12985 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 3619,12985 L 4463,12985 4463,11567 3619,11567 3619,12985 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 9529,12985 L 10374,12985 10374,11801 9529,11801 9529,12985 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 15438,12985 L 16283,12985 16283,11767 15438,11767 15438,12985 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 21349,12985 L 22193,12985 22193,11771 21349,11771 21349,12985 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 4463,12985 L 5308,12985 5308,10316 4463,10316 4463,12985 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 10374,12985 L 11218,12985 11218,10718 10374,10718 10374,12985 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 16283,12985 L 17127,12985 17127,10647 16283,10647 16283,12985 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 22193,12985 L 23037,12985 23037,10643 22193,10643 22193,12985 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 5308,12985 L 6152,12985 6152,8265 5308,8265 5308,12985 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 11218,12985 L 12062,12985 12062,9932 11218,9932 11218,12985 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 17127,12985 L 17971,12985 17971,9729 17127,9729 17127,12985 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 23037,12985 L 23882,12985 23882,9705 23037,9705 23037,12985 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 6152,12985 L 6996,12985 6996,5636 6152,5636 6152,12985 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 12062,12985 L 12907,12985 12907,6692 12062,6692 12062,12985 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 17971,12985 L 18816,12985 18816,6126 17971,6126 17971,12985 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 23882,12985 L 24726,12985 24726,5902 23882,5902 23882,12985 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 6996,12985 L 7841,12985 7841,2602 6996,2602 6996,12985 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 12907,12985 L 13750,12985 13750,6023 12907,6023 12907,12985 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 18816,12985 L 19660,12985 19660,5043 18816,5043 18816,12985 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 24726,12985 L 25570,12985 25570,4405 24726,4405 24726,12985 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="4907" y="13553"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Copy</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10789" y="13553"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Scale</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16822" y="13553"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Add</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="22646" y="13553"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">Triad</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1912" y="13106"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">0</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="11641"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">100</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="10176"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">200</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="8711"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">300</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="7247"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">400</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="5782"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">500</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="4317"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">600</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="2852"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">700</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="1529" y="1387"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">800</tspan></tspan></tspan></text>
+ <path fill="rgb(0,69,134)" stroke="none" d="M 9241,576 L 9136,576 9136,365 9347,365 9347,576 9241,576 Z "/>
+ <path fill="rgb(255,66,14)" stroke="none" d="M 10589,576 L 10484,576 10484,365 10695,365 10695,576 10589,576 Z "/>
+ <path fill="rgb(255,211,32)" stroke="none" d="M 11937,576 L 11832,576 11832,365 12043,365 12043,576 11937,576 Z "/>
+ <path fill="rgb(87,157,28)" stroke="none" d="M 13285,576 L 13180,576 13180,365 13390,365 13390,576 13285,576 Z "/>
+ <path fill="rgb(126,0,33)" stroke="none" d="M 14633,576 L 14527,576 14527,365 14738,365 14738,576 14633,576 Z "/>
+ <path fill="rgb(131,202,255)" stroke="none" d="M 16172,576 L 16066,576 16066,365 16277,365 16277,576 16172,576 Z "/>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="9447" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">1 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="10795" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">2 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12143" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">4 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="13490" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">8 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="14838" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">16 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="16377" y="590"><tspan font-family="Liberation Sans, sans-serif" font-size="353px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">32 VM</tspan></tspan></tspan></text>
+ <text class="SVGTextShape"><tspan class="TextParagraph"><tspan class="TextPosition" x="12359" y="14318"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">STREAM Operation</tspan></tspan></tspan></text>
+ <text class="SVGTextShape" transform="rotate(-90 825 9644)"><tspan class="TextParagraph"><tspan class="TextPosition" x="825" y="9644"><tspan font-family="Liberation Sans, sans-serif" font-size="318px" font-weight="400" fill="rgb(0,0,0)" stroke="none" style="white-space: pre">GBytes/sec (Average of all VMs)</tspan></tspan></tspan></text>
+</svg>

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -64,6 +64,16 @@
       </author>
       <author>
         <personname>
+          <firstname>Dario</firstname>
+	  <surname>Faggioli</surname>
+        </personname>
+        <affiliation>
+          <jobtitle>Virtualization Specialist</jobtitle>
+          <orgname>SUSE</orgname>
+        </affiliation>
+      </author>
+      <author>
+        <personname>
           <firstname>Brent</firstname>
           <surname>Hollingsworth</surname>
         </personname>
@@ -1721,10 +1731,8 @@ epyc:~ # perf script
 
   </sect1>
 
-
-  <!--
   <sect1 xml:id="sec-amd-epyc2-virtualization">
-    <title>Using AMD EPYC 7003 Series Processors for virtualization</title>
+    <title>Using AMD EPYC 9004 Series Processors for virtualization</title>
 
     <para> Running Virtual Machines (VMs) has some aspects in common with running
         <quote>regular</quote> tasks on a host operating system. Therefore, most of the tuning
@@ -1733,7 +1741,7 @@ epyc:~ # perf script
     <para> However, virtualization workloads do pose their own specific challenges and some special
       considerations need to be made, to achieve a better tailored and more effective set of tuning
       advice, for cases where a server is used only as a virtualization host. And this is especially
-      relevant for large systems, such as AMD EPYC 7003 Series Processors. </para>
+      relevant for large systems, such as AMD EPYC 9004 Series Processors. </para>
 
     <para>This is because:</para>
 
@@ -1777,7 +1785,7 @@ epyc:~ # perf script
       and the VMs, in a way that performance comparable to the ones of the host can be achieved. </para>
 
     <para> Both the Kernel-based Virtual Machine (KVM) and the Xen-Project hypervisor (Xen), as
-      available in SUSE Linux Enterprise Server 15 SP2, provide mechanisms to enact this kind of
+      available in SUSE Linux Enterprise Server 15 SP4, provide mechanisms to enact this kind of
       resource partitioning and allocation. </para>
 
     <note>
@@ -1800,16 +1808,16 @@ epyc:~ # perf script
     <para> No details are given, here, about how to install and configure a system so that it
       becomes a suitable virtualization host. For similar instructions, refer to the SUSE
       documentation at <link
-        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-vt-installation.html"
-        > SUSE Linux Enterprise Server 15 SP2 Virtualization Guide: Installation of Virtualization
+        xlink:href="https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-vt-installation.html"
+        > SUSE Linux Enterprise Server 15 SP4 Virtualization Guide: Installation of Virtualization
         Components</link>. </para>
 
     <para> The same applies to configuring things such as networking and storage, either for the
       host or for the VMs. For similar instructions, refer to suitable chapters of OS and
       virtualization documentation and manuals. As an example, to know how to assign network
       interfaces (or ports) to one or more VMs, for improved network throughput, refer to <link
-        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-libvirt-config-gui.html#sec-libvirt-config-pci"
-        > SUSE Linux Enterprise Server 15 SP2 Virtualization Guide: Assigning a Host PCI Device to a
+        xlink:href="https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-libvirt-config-gui.html#sec-libvirt-config-pci"
+        > SUSE Linux Enterprise Server 15 SP4 Virtualization Guide: Assigning a Host PCI Device to a
         VM Guest</link>. </para>
 
     <sect2 xml:id="sec-allocating-resources-hostos">
@@ -1840,13 +1848,11 @@ epyc:~ # perf script
       <para> In terms of CPUs, depending on the workload, it may be fine to use all the physical
         CPUs for the VMs (and this is in fact how the benchmarks in the experimental section of this
         guide have been conducted). On the other hand, if it is necessary to keep some CPUs for the
-        host Os / dom0, we advise to reserve at least one physical core on each NUMA node. If that
-        is not possible, consider reserving at least one core on the NUMA node(s) that have IO
-        channels attached to it (them). In fact, host OS activities are mostly related to performing
-        IO for VMs. It is beneficial for performance if the kernel threads that handle devices can
-        run on the node to which the devices themselves are attached. As an example, in the system
-        shown in <xref linkend="fig-epyc-topology"/>, this would mean reserving at least one
-        physical core for the host OS on node 0. </para>
+        host Os / dom0, we advise to reserve at least one physical core on each NUMA node.
+        This is especially true for a system like the one show in <xref linkend="fig-epyc-topology"/>.
+        In fact, host OS activities are mostly related to performing
+        IO for VMs and it is beneficial for performance if the kernel threads that handle devices can
+        run on the nodes to which the devices themselves are attached, which is both NUMA nodes, in our case. </para>
 
       <para> System administrators need to be able to reach out and login to the system, to monitor,
         manage and troubleshoot it. Therefore, it is possible that even more resources needs to be
@@ -1857,10 +1863,10 @@ epyc:~ # perf script
       <sect3 xml:id="sec-allocating-resources-hostos-kvm">
         <title>Reserving CPUs and memory for the host on KVM</title>
 
-        <para> When using KVM, sparing, for example, 2 cores and 12 GB of RAM for the host OS is
-          done by stopping creating VMs when the total number of vCPUs of all VMs has reached 252
+        <para> When using KVM, sparing, for example, 12 cores (i.e., one full core for each CCX) and 64 GB of RAM for the host OS is
+          done by stopping creating VMs when the total number of vCPUs of all VMs has reached 336
           (as each core has 2 threads) or when the total cumulative amount of allocated RAM has
-          reached 220 GB. </para>
+          reached 690 GB. </para>
 
         <para> To make sure that these CPUs are not used by the virtual machines and are available
           to the host, virtual CPU pinning (discussed later in this document) can be used. There are
@@ -1873,14 +1879,14 @@ epyc:~ # perf script
         <title>Reserving CPUs and memory for the host on Xen</title>
 
         <para> When using Xen, dom0 resource allocation needs to be done explicitly at system boot
-          time. For example, assigning 8 physical cores and 12 GB of RAM to it is done by specifying
+          time. For example, assigning 12 physical cores and 64 GB of RAM to it is done by specifying
           the following additional parameters on the hypervisor boot command line (for example, by
           editing <filename>/etc/defaults/grub</filename>, and then updating the boot loader): </para>
 
-        <screen>dom0_mem=12288M,max:12288M dom0_max_vcpus=16</screen>
+        <screen>dom0_mem=65536M,max:65536M dom0_max_vcpus=24</screen>
 
-        <para> The number of vCPUs is 16 because we want Dom0 to have 8 physical cores, and the AMD
-          EPYC 7003 Series Processor has Symmetric multithreading (SMT). 12288M memory (that is 12
+        <para> The number of vCPUs is 24 because we want Dom0 to have 12 physical cores, and the AMD
+          EPYC 9004 Series Processor has Symmetric multithreading (SMT). 65536M memory (that is 64
           GB) is specified both as current and as maximum value, to prevent Dom0 from using
           ballooning (see <link
             xlink:href="https://wiki.xenproject.org/wiki/Tuning_Xen_for_Performance#Memory">
@@ -1907,7 +1913,7 @@ epyc:~ # perf script
           those same node(s). When the Dom0 has booted, it is still possible to use <command>xl
             vcpu-pin</command> or <command>virsh vcpupin</command> to change where its vCPUs will be
           scheduled. But the memory will never be moved from where it has been allocated during
-          boot. On AMD EPYC 7003 Series Processors, using this option is not recommended. </para>
+          boot. On AMD EPYC 9004 Series Processors, using this option is not recommended. </para>
 
       </sect3>
 
@@ -1953,8 +1959,8 @@ epyc:~ # perf script
 
       <para> The value <parameter>&lt;number of hugepages></parameter> can be computed by taking
         the amount of memory we want to devoted to VMs, and dividing it by the page size (1 GB). For
-        example on our host with 256 GB of RAM, creating 200 Huge Pages means we can accommodate up
-        to 210 GB of VMs' RAM, and leave plenty (~50GB) to the host OS. </para>
+        example on our host with 754 GB of RAM, creating 672 Huge Pages means we can accommodate up
+        to  GB of VMs' RAM, and leave plenty (~80GB) to the host OS. </para>
 
       <para> On Xen, none of the above is necessary. In fact, Dom0 is a paravirtualized guest, for
         which Huge Pages support is not present. On the other hand, for the memory used for the
@@ -1965,10 +1971,6 @@ epyc:~ # perf script
 
     <sect2 xml:id="sec-automatic-numa-balancing">
       <title>Automatic NUMA balancing</title>
-
-      <para> On Xen, Automatic NUMA Balancing (NUMAB) in the host OS should be disabled. Dom0 is,
-        currently, a paravirtualized guest without a (virtual) NUMA topology and, thus, NUMAB would
-        be totally useless. </para>
 
       <para> On KVM, NUMAB can be useful in dynamic virtualization scenarios, where VMs are created,
         destroyed and re-created relatively quickly. Or, in general, it can be useful in cases where
@@ -1987,6 +1989,9 @@ epyc:~ # perf script
 
       <screen>echo 0 > /proc/sys/kernel/numa_balancing</screen>
 
+      <para> On Xen, Automatic NUMA Balancing (NUMAB) in the host OS should be disabled. Dom0 is,
+        currently, a paravirtualized guest without a (virtual) NUMA topology and, thus, NUMAB would
+        be totally useless. </para>
     </sect2>
 
     <sect2 xml:id="sec-services-daemons-power">
@@ -1998,7 +2003,7 @@ epyc:~ # perf script
       <para> For example, <package>tuned</package> should either not be used, or the profile should
         be set to one that does not implicitly put the CPUs in polling mode. Both
           <package>throughput-performance</package> and <package>virtual-host</package> profiles
-        from SUSE Linux Enterprise Server 15 SP2 are okay, as neither of them touches
+        from SUSE Linux Enterprise Server 15 SP4 are okay, as neither of them touches
           <filename>/dev/cpu_dma_latency</filename>. </para>
 
       <para>
@@ -2029,13 +2034,14 @@ epyc:~ # perf script
     <sect2 xml:id="sec-sev-host">
       <title>Secure Encrypted Virtualization (SEV)</title>
 
-      <para> Secure Encrypted Virtualization (SEV) technology, supported on the 3rd Generation AMD
-        EPYC Processors, allows the memory of the VMs to be encrypted. Enabling it for a VM happens
-        in the VM's own configuration file, but there are preparation steps that needs to occur at
+      <para> Secure Encrypted Virtualization, with Encrypted State (SEV-ES) technology, supported on the 4rd Generation AMD
+        EPYC Processors, allows the memory of the VMs to be encrypted. It enables an even greater level of
+        confidentiality, as compared to plain SEV, supported in the previous generation of the processor
+        For using SEV-ES for a VM, we need to enable it in the VM's own configuration file, but there are preparation steps that needs to occur at
         the host level. </para>
 
       <para> The <package>libvirt</package> documentation contains all the necessary steps required
-        for enabling SEV on a host that supports it. It has been enough to add the following boot
+        for enabling SEV-ES on a host that supports it. It has been enough to add the following boot
         parameters to the host kernel command line, in the boot loader: </para>
 
       <screen>mem_encrypt=on kvm_amd.sev=1</screen>
@@ -2044,21 +2050,23 @@ epyc:~ # perf script
           xlink:href="https://libvirt.org/kbase/launch_security_sev.html#Host"> Libvirt
           documentation: Enabling SEV on the host</link>. </para>
 
+<!-- DOUBLE CHECK THE NUMBERS FROM THE EXPERIMENTS
       <para> It should be noted that, at least as far as the workload analyzed in this document,
-        enabling SEV on the host has not caused any noticeable performance degradation. In fact,
+        enabling SEV-ES on the host has not caused any noticeable performance degradation. In fact,
         running CPU and memory intensive workloads, both on the host and in VMs, with or without the
         parameters above added to the host kernel boot command line, resulted in indistinguishable
         results. Therefore, enabling SEV at the host level can be considered safe, from the point of
         view of not hurting performance of VMs and workloads that will not enable VM memory
         encryption. Of course, this applies to when SEV is enabled for the host and is
           <emphasis>not</emphasis> used for encrypting VMs. </para>
+-->
 
-      <para>What happens when SEV is used for encrypting VMs' memory will be described later in the
+      <para>What happens when SEV-ES is used for encrypting VMs' memory will be described later in the
         guide.</para>
 
       <note>
         <title>SEV on Xen</title>
-        <para>In SUSE Linux Enterprise Server 15 SP2, SEV is not available on Xen.</para>
+        <para>In SUSE Linux Enterprise Server 15 SP4, SEV-ES is not available on Xen.</para>
       </note>
 
     </sect2>
@@ -2070,8 +2078,8 @@ epyc:~ # perf script
 
     <para> For instructions on how to create an initial VM configuration, start the VM, and install
       a guest OS, refer to the SUSE documentation at <link
-        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-kvm-inst.html">
-        SUSE Linux Enterprise Server 15 SP2 Virtualization Guide: Guest Installation</link>. </para>
+        xlink:href="https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-kvm-inst.html">
+        SUSE Linux Enterprise Server 15 SP4 Virtualization Guide: Guest Installation</link>. </para>
 
     <para>From a VM configuration perspective, the two most important factors for achieving top
       performance on CPU and memory bound workloads are:</para>
@@ -2100,7 +2108,7 @@ epyc:~ # perf script
         importance that the initial placement of the VMs is as optimal as possible. Both Xen and KVM
         can make <quote>educated guesses</quote> on what a good placement might be. For the purpose
         of this document, however, we are interested in what is the absolute best possible initial
-        placement of the VMs, taking into account the specific characteristics of AMD EPYC 7003
+        placement of the VMs, taking into account the specific characteristics of AMD EPYC 9004
         Series Processor systems. And this can only be achieved by <emphasis role="strong"
           >manually</emphasis> doing the initial placement. Of course, this comes at the price of
         reduced flexibility, and is only possible when there is no oversubscription. </para>
@@ -2134,27 +2142,32 @@ epyc:~ # perf script
         in the example below:</para>
 
       <screen>
-&lt;vcpu placement='static'>240&lt;/vcpu>
+&lt;vcpu placement='static'>288&lt;/vcpu>
 &lt;cputune>
-  &lt;vcpupin vcpu='0' cpuset='4'/>
-  &lt;vcpupin vcpu='1' cpuset='132'/>
-  &lt;vcpupin vcpu='2' cpuset='5'/>
-  &lt;vcpupin vcpu='3' cpuset='133'/>
+  &lt;vcpupin vcpu='0' cpuset='0'/>
+  &lt;vcpupin vcpu='1' cpuset='192'/>
+  &lt;vcpupin vcpu='2' cpuset='1'/>
+  &lt;vcpupin vcpu='3' cpuset='193'/>
   ...
 &lt;/cputune>
       </screen>
 
-      <para> The value <parameter>240</parameter> means that the VM will have 240 vCPUs. The
+      <para> The value <parameter>288</parameter> means that the VM will have 288 vCPUs. The
           <parameter>static</parameter> guarantees that each vCPU will stay on the pCPU(s) on which
         it is <quote>pinned</quote> to. The various <parameter>&lt;vcpupin></parameter> elements
         are where the mapping between vCPUs and pCPUs is established (<parameter>vcpu</parameter>
         being the vCPU ID and <parameter>cpuset</parameter> being either one or a list of pCPU IDs). </para>
 
-      <para> To use all of the available 256 pCPUs for a VM, specify <parameter>256</parameter>. In
-        addition to that, though, the following element should be added in the
+      <para> In order to be able to create VMs with more than 255 vCPUs,
+        the following element should be added in the
           <parameter>&lt;device></parameter> section:</para>
 
       <screen>
+&lt;features>
+  ...
+  &lt;ioapic driver="qemu"/>
+&lt;/features>
+...
 &lt;devices>
   ...
   &lt;iommu model='intel'>
@@ -2165,7 +2178,7 @@ epyc:~ # perf script
     </screen>
 
       <para> When pinning vCPUs to pCPUs, adjacent vCPU IDs (like vCPU ID 0 and vCPU ID 1) must be
-        assigned to host SMT siblings (like pCPU 65 and pCPU 193, on our test server). In fact, QEMU
+        assigned to host SMT siblings (like pCPU 4 and pCPU 196, on our test server). In fact, QEMU
         uses a static SMT sibling CPU ID assignment. This is how we guarantee that virtual SMT
         siblings will always execute on actual physical SMT siblings. </para>
 
@@ -2173,20 +2186,25 @@ epyc:~ # perf script
         and memory for VM of varying sizes of VMs, on the reference system for this guide (see <xref
           linkend="fig-epyc-topology"/>. </para>
 
+     <para>Note that, despite the fact that the server has 384 pCPUs, a VM in SUSE Linux Enterprise
+       15 SP4 cannot have more than 288 vCPUs (the value will be higher in future versions of SUSE Linux
+       Enterprise Server). Of course, we can still use all the pCPUs of the server, when creating multiple VMs.
+     </para>
+
       <sect3 xml:id="sec-placement-one-vm">
-        <title>Placement of only one large VM</title>
+        <title>Placement of a single large VM</title>
 
         <para> An interesting use case when <quote>only one</quote> VM is used. Reasons for doing
           something like that include security/isolation, flexibility, high availability, and
           others. In this cases, typically, the VM is almost as large as the host itself. </para>
 
-        <para> Let us, therefore, consider a VM with all of the 256 vCPUs and 200 GB of RAM. Such VM
+        <para> Let us, therefore, consider a VM with 288 vCPUs and 672 GB of RAM. Such VM
           spans multiple host NUMA nodes and therefore it is recommended to create a virtual NUMA
           topology for it. </para>
 
         <para> We should create a virtual topology with 2 virtual NUMA nodes (that is, as many as
-          there are physical NUMA nodes), and split the VM’s memory equally among them. The 256
-          vCPUs are assigned to the 2 nodes, 128 on each. </para>
+          there are physical NUMA nodes), and split the VM’s memory equally among them. The 672
+          vCPUs are assigned to the 2 nodes, 336 on each. </para>
 
         <para> The VM Memory must be split equally among the 2 nodes. At this point, if a suitable
           virtual topology is also provided to the VM, each of the VM’s vCPUs will access its own
@@ -2198,13 +2216,14 @@ epyc:~ # perf script
           explained:</para>
 
         <screen>
+vm1:~ # numactl --hardware
 available: 2 nodes (0-1)
-node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127
-node 0 size: 100670 MB
-node 0 free: 100003 MB
-node 1 cpus: 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255
-node 1 size: 100768 MB
-node 1 free: 100077 MB
+node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143
+node 0 size: 354661 MB
+node 0 free: 352996 MB
+node 1 cpus: 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256 257 258 259 260 261 262 263 264 265 266 267 268 269 270 271 272 273 274 275 276 277 278 279 280 281 282 283 284 285 286 287
+node 1 size: 321929 MB
+node 1 free: 320767 MB
 node distances:
 node   0   1
   0:  10  32
@@ -2213,34 +2232,27 @@ node   0   1
 
         <para> This is analogous to the host topology, also from the point of view of NUMA node
           distances (as the <package>libvirt</package> version present in SUSE Linux Enterprise
-          Server 15 SP2, allows us to define the virtual nodes distance table). The only differences
+          Server 15 SP4 allows us to define the virtual nodes distance table). The only differences
           are the number of CPUs, their APIC IDs and the amount of memory. </para>
 
         <para>See <xref linkend="sec-appendix-a"/> for an almost complete VM configuration
           file.</para>
 
-        <para>An alternative setup would be to leave some pCPUs to the host, for example using
-            <quote>only</quote> 240 vCPUs for the VM. As said already, full cores must always be
-          used. That means, assign vCPUs 0 and 1 to Core L#4, vCPUs 2 and 3 to Core L#5, vCPUs 4 and
-          5 to Core L#6, etc. To enact this, we must pin vCPUs 0 and 1 to pCPUs 4 and 132; vCPUs 2
-          and 3 to pCPUs 5 and 133; vCPUs 4 and 5 to pCPUs 6 and 134, etc. And, of course, the two
-          nodes must have the same number of vCPUs. </para>
-
-        <para> In such a setup, cores L#0, L#1, L#2 and L#3 from host NUMA node #0 and cores L#64,
-          L#65, L#66 and L#67 from host NUMA node #1 will be reserved to the host. This, however,
-          means splitting two of the dies, which in turns means there will be some L3 cache
-          interference between the host and the VM. If that damages the performance of the workloads
-          of interest too much, avoid it, by giving to the VM 224 vCPUs. </para>
+        <para>As said already, full cores must always be used. If possible always fully use CCXes/dies too.
+          Since each die has 16 CPUs, that means that a VM with 288 vCPUs will use 9 CCXes on each of the 2 nodes
+          (as 9 x 16 x 2 is indeed 288).
+          So, for instance, vCPUs 0 to 15 can be assigned to Cores L#0 to L#7 (and hence to CPUs P#0 to P#7 and P#192 to P#199), on node P#0;
+          vCPUs 16 to 31 to Cores L#$8 to L#15, and so on. No vCPU will be pinned, on the other hand, on Cores L#72 to L#95.
+          And the same on node P#1.
+          This guarantees that there will be no interference between the VM and the host via the L3 cache that the CPUs of each die share.</para>
 
       </sect3>
 
       <sect3 xml:id="sec-placement-two-vms">
         <title>Placement of two large VMs</title>
 
-        <para> If wanting to run two VMs, they can have 128 vCPUs and 100 GB memory each. The
-          recommendation, in this case, is to put each VM on one host NUMA node. This way, VMs no
-          longer span multiple host NUMA nodes, and hence there is no need to define virtual NUMA
-          nodes, as part of their topologies. </para>
+        <para> If wanting to run two VMs, they both can have 192 vCPUs and 336 GB memory each, so that each one can fit in one of the host NUMA nodes.
+          This also means that there is no need to define virtual NUMA nodes in their configuration.</para>
 
         <para>Placing each VM on one node means that workloads running inside each of them will
           never need to use inter-socket interconnect.</para>
@@ -2249,10 +2261,11 @@ node   0   1
           follows:</para>
 
         <screen>
+vm1:~ # numactl --hardware
 available: 1 nodes (0)
-node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127
-node 0 size: 100572 MB
-node 0 free: 100040 MB
+node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191
+node 0 size: 676778 MB
+node 0 free: 675046 MB
 node distances:
 node   0
   0:  10
@@ -2261,16 +2274,19 @@ node   0
       </sect3>
 
       <sect3 xml:id="sec-placement-ten-vms">
-        <title>Placement of four to sixteen medium-size VMs</title>
+        <title>Placement of four to twentyfour medium-size VMs</title>
 
         <para> Following the same principles, we can <quote>split</quote> each node in 2, and have 4
-          VMs with 64 vCPUs and up to 48 GB of RAM each. </para>
+          VMs with 96 vCPUs and up to 168 GB of RAM each.
+          Or, maybe, have 12 VMs with 32 vCPUs and 56 GB RAM each.
+          And even 24 VMs, with 16 vCPUs and 28 GB RAM.</para>
 
-        <para> Or even have 16 VMs with 16 vCPUs and 12 GB RAM each. </para>
+        <para>In the first case, each VM will span 6 host dies. In the second, 2.
+          In the third one, each VM will be pinned to 1 die.</para>
 
         <para> In both cases, VMs will not need to (and must not) be put across the host NUMA nodes
           boundary, and hence they do not need to be NUMA-aware. They still benefit from having a
-          virtual topology, in terms of cores and threads, which matches the resource they are
+          virtual topology, in terms of cores, threads and dies which matches the resource they are
           using. You will find more details about this in following sections. </para>
 
       </sect3>
@@ -2279,29 +2295,35 @@ node   0
         <title>Placement of many small VMs</title>
 
         <para>If small VMs are the target, VMs with either 8, 4 or 2 vCPUs each can be created and
-          efficiently allocated on AMD EPYC 7003 Series Processors servers.</para>
+          efficiently allocated on AMD EPYC 9004 Series Processors servers.</para>
 
-        <para> VMs with 8 vCPUs <quote>occupies</quote> half a dies, and we can have 32 of them. VMs
-          with either 4 or 2 vCPUs will be given 2 and 1 host cores and we can have 64 and 128 of
+        <para> VMs with 8 vCPUs <quote>occupies</quote> half a die, and we can have 48 of them. VMs
+          with either 4 or 2 vCPUs will be given 2 and 1 host cores and we can have 96 and 192 of
           them, respectively. And this is all possible without the need for any of the VMs to span
           more than one host NUMA node. </para>
 
+        <para>Of course, in all these cases, VMs are sharing dies, which means they will interfere among each others via the L3 caches.
+          This may or may not be a problem, but there is no way around it, as soon as more VMs than the number of available dies are necessary.
+          The performance impact of such sharing should be tolerable, in most cases, for these configurations, but this needs to be assessed with tests and benchmarks.
+          If that is not the case, then the recommendation is to not go above 24 VMs.
+          More clever (but also more complex) tuning strategies can be designed, but they would require further a-priori knowledge of, for instance, what is the workload and/or the load profile of the various VMs, which may not be available as an information.</para>
+
         <note>
-          <title>Hundreds of VMs with 256 GB of RAM</title>
+          <title>Hundreds of VMs with limited RAM size and disk sapce</title>
           <para> When the number of VM increases so much, the limiting factor will become the
-            memory. With ~200 GB of RAM available for VMs on our server, we could give only 1 GB of
-            RAM to each of the 128 VMs. Of course, this limitation is only an issue of the system
-            used as reference for this guide. The AMD EPIC 7003 Series Processor architecture itself
+            memory or the disk. With ~700 GB of RAM available for VMs on our server, we can give only 3 GB of
+            RAM to each of the 192 VMs of the last example above. Of course, this limitation is only an issue of the system
+            used as reference for this guide. The AMD EPIC 9004 Series Processor architecture itself
             can accommodate much more RAM. </para>
         </note>
 
         <para> In cases when it is enough or desirable to have VMs with only 1 vCPUs, it is
-          recommended to still not go beyond 128, and assign no less than one full core to each VM.
+          recommended to still not go beyond 192, and assign no less than one full core to each VM.
           It should be avoided to have vCPUs from different VMs running on two siblings threads of
           the same core. Such a solution, although functional, is not ideal for all the cases where
           good and consistent performance within VMs is a goal. What can be done for each VM and for
           each core is to use one of the two threads for the actual vCPU, and the other for its IO
-          thread(s), on the host. This solution allows to take advantage of the full 3rd Generation
+          thread(s), on the host. This solution allows to take advantage of the full 4th Generation
           AMD EPYC processing power. However, we advise to check and verify whether this is a good
           setup and if it brings performance benefits for the specific workloads of interest, before
           committing to it. </para>
@@ -2343,7 +2365,7 @@ node   0
       <note>
         <title>Not covering oversubscribed scenarios</title>
         <para> This guide does not cover in great details oversubscribed scenarios. However, given
-          the large number of CPUs available on an AMD EPYC 7003 Series Processor system and the
+          the large number of CPUs available on an AMD EPYC 9004 Series Processor system and the
           huge amount of memory the architecture supports, this is not considered a limitation.
         </para>
       </note>
@@ -2351,16 +2373,16 @@ node   0
       <bridgehead>CPU Oversubscription</bridgehead>
 
       <para> CPU oversubscription happens when the total cumulative number of vCPUs from all VMs
-        becomes higher than 256. Such situation unavoidably introduces latencies, and leads to lower
+        becomes higher than 384. Such situation unavoidably introduces latencies, and leads to lower
         performance than when host resources are just enough. It is, however, impossible to tell a
         priori by what extent this happens, at least not without a detailed knowledge of the actual
         workload. </para>
 
       <para> If we knew in advance that the load on each vCPU will always stay below 50%, we could
-        assume that even oversubscribing the host by a factor of 2 (like with ~512 vCPUs, in our
+        assume that even oversubscribing the host by a factor of 2 (like with ~768 vCPUs in total, in our
         case!) will work well. On the other hand, if we knew that the load that each vCPU tries to
         impose on the system is always 100%, creating even 1 vCPUs more than the host has pCPUs
-        would already lead to a misconfiguration. </para>
+        can be considered a misconfiguration. </para>
 
       <para> When under oversubscription, exclusive 1-to-1 vCPU to pCPU assignment may not the best
         approach. However, we need to trust the hypervisor scheduler to handle the situation well
@@ -2432,30 +2454,29 @@ node   0
         <para>To ensure the VM has a vCPU topology, use the following:</para>
 
         <screen>
-&lt;cpu mode='custom' match='exact' check='none'>
-  &lt;model fallback='allow'>EPYC&lt;/model>
-  &lt;topology sockets='2' cores='64' threads='2'/>
-  &lt;numa>
-    &lt;cell id='0' cpus='0-127' memory='104857600' unit='KiB'>
-      &lt;distances>
-        &lt;sibling id='0' value='10'/>
-        &lt;sibling id='1' value='32'/>
-      &lt;/distances>
-    &lt;/cell>
-    &lt;cell id='1' cpus='128-255' memory='104857600' unit='KiB'>
-      &lt;distances>
-        &lt;sibling id='0' value='32'/>
-        &lt;sibling id='1' value='10'/>
-      &lt;/distances>
-    &lt;/cell>
-   &lt;/numa>
-&lt;/cpu>
+  &lt;cpu mode="host-model" check="none">
+    &lt;topology sockets="2" dies="9" cores="8" threads="2"/>
+    &lt;numa>
+      &lt;cell id="0" cpus="0-143" memory="369098752" unit="KiB">
+        &lt;distances>
+          &lt;sibling id="0" value="10"/>
+          &lt;sibling id="1" value="32"/>
+        &lt;/distances>
+      &lt;/cell>
+      &lt;cell id="1" cpus="144-287" memory="369098752" unit="KiB">
+        &lt;distances>
+          &lt;sibling id="0" value="32"/>
+          &lt;sibling id="1" value="10"/>
+        &lt;/distances>
+      &lt;/cell>
+    &lt;/numa>
+  &lt;/cpu>
         </screen>
 
         <para> The <parameter>&lt;topology></parameter> element specifies the CPU
           characteristics. In this case, we are creating vCPUs which will be seen by the guest OS as
-          being arranged in 2 sockets, each of which has 64 cores, each of which has 2 threads. And
-          this is how we match, for the one big VM, the topology of the host. </para>
+          being arranged in 2 sockets, each of which has 9 dies, each of which has 8 cores with 2 threads (i.e., 16 CPUs).
+          And this is how we match, for the one big VM, the topology of the host. </para>
 
         <para> Each <parameter>&lt;cell></parameter> element defines one virtual NUMA node,
           specifying how much memory and which vCPUs are part of it. The
@@ -2466,77 +2487,81 @@ node   0
 
         <para> CPU model is how the VM is told what type of vCPUs should be <quote>emulated</quote>,
           for example, what features and special instructions and extensions will be available. To
-          achieve best performance, using <parameter>mode='host-passthrough'</parameter> is often
-          the right choice. However, at least on SUSE Linux Enterprise Server 15 SP2, this produces
+          achieve best performance, using <parameter>model='host-passthrough'</parameter> is often
+          the right choice. However, at least on SUSE Linux Enterprise Server 15 SP4, this produces
           wrong results. In fact, such setting prevents the topology - despite it being described
           correctly in the <parameter>&lt;topology></parameter> element - from being interpreted
           correctly, inside the VM. This is visible in the output of the command
             <command>lscpu</command>: </para>
 
         <screen>
+vm1:~ # lscpu
 ...
-CPU(s):              256
-On-line CPU(s) list: 0-255
-Thread(s) per core:  1
-Core(s) per socket:  128
-Socket(s):           2
-NUMA node(s):        2
+CPU(s):                  288
+  On-line CPU(s) list:   0-287
+Vendor ID:               AuthenticAMD
+  Model name:            AMD EPYC 9654 96-Core Processor
+    CPU family:          25
+    Model:               17
+    Thread(s) per core:  1
+    Core(s) per socket:  288
+    Socket(s):           1
 ...
-L1d cache:           64K
-L1i cache:           64K
-L2 cache:            512K
-L3 cache:            16384K
-NUMA node0 CPU(s):   0-127
-NUMA node1 CPU(s):   128-255
+Caches (sum of all):
+  L1d:                   18 MiB (288 instances)
+  L1i:                   18 MiB (288 instances)
+  L2:                    144 MiB (288 instances)
+  L3:                    4.5 GiB (288 instances)
 ...
-        </screen>
+       </screen>
 
-        <para> Benchmarks have shown that misunderstanding the CPUs as being all individual cores,
-          without there being SMT, has a negative impact on performance. Note that the problem not
-          only involves CPU topology, it is also the cache hierarchy structure which is not
-          constructed consistently with the host. In fact, while the sizes of L1d and L1i caches is
-          wrong (it is 64k instead than 32k, see <xref linkend="fig-epyc-topology"/>). It is also
-          the information about which CPUs share what caches that is completely misconfigured, as
-          shown here: </para>
+        <para>Both the CPU topology and the cache layout, as seen from inside of the VM, are completely wrong, and can affect performance of applications running inside the VM.
+          In fact, not only the sizes of the various cache levels are wrong. It is also the information about which CPUs share what caches that is completely misconfigured, as shown also here: </para>
+
+        <para>Of course, now it is the <parameter>Model name:</parameter> that is not completely correct.
+          But both the CPU and caches layout is much more in line with what we wanted to achieve by tuning the VM configuration (remember that the VM has 288 vCPUs).</para>
 
         <screen>
-cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
 0
-cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
 0
-cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
 0
-cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
-0-128
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-143
         </screen>
 
-        <para> The VM thinks that L1d, L1i and L2 are private of each vCPU. That is not the case, as
+        <para> The VM thinks that L1d, L1i and L2 are private of each vCPU, while that is not the case, as
           they are shared by the two threads of each core. Even worse, it thinks that L3 is shared
           across all the vCPUs of a socket, which is not true, as it is shared only among 8 cores
           (that is 16 vCPUs). </para>
 
-        <para> For this reason, the recommendation is to use <parameter>EPYC</parameter> as the CPU
-          model (as a 3rd Generation AMD EPYC Processor model is not yet available). This enables a
-          virtual topology inside the VM what is more consistent (although not perfectly identical)
-          with the one of the host, and benchmark shows a beneficial effect on performance coming
-          from that. The output of <command>lscpu</command> with <parameter>EPYC</parameter> as a
+        <para> For this reason, the recommendation is to use <parameter>EPYC-Milan</parameter> as the CPU
+          model (as an appropriate model for 4th Generation AMD EPYC Processors is not yet available) either manually or by using <parameter>model='host-model'</parameter>.
+          This enables a virtual topology inside the VM what is more consistent (although not perfectly identical)
+          with the one of the host, and benchmarks show a beneficial effect on performance coming
+          from that. The output of <command>lscpu</command> with <parameter>EPYC-Milan</parameter> as a
           model is shown below: </para>
 
         <screen>
+vm1:~ # lscpu
 ...
-CPU(s):              256
-On-line CPU(s) list: 0-255
-Thread(s) per core:  2
-Core(s) per socket:  64
-Socket(s):           2
-NUMA node(s):        2
+CPU(s):                  288
+  On-line CPU(s) list:   0-287
+Vendor ID:               AuthenticAMD
+  Model name:            AMD EPYC-Milan Processor
+    CPU family:          25
+    Model:               1
+    Thread(s) per core:  2
+    Core(s) per socket:  72
+    Socket(s):           2
 ...
-L1d cache:           32K
-L1i cache:           64K
-L2 cache:            512K
-L3 cache:            8192K
-NUMA node0 CPU(s):   0-127
-NUMA node1 CPU(s):   128-255
+Caches (sum of all):
+  L1d:                   4.5 MiB (144 instances)
+  L1i:                   4.5 MiB (144 instances)
+  L2:                    72 MiB (144 instances)
+  L3:                    576 MiB (18 instances)
 ...
         </screen>
 
@@ -2548,28 +2573,97 @@ NUMA node1 CPU(s):   128-255
           inside the VM that matches the one of the host. This is shown here: </para>
 
         <screen>
-cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
 0-1
-cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
 0-1
-cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
 0-1
-cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
-0-7
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-15
         </screen>
 
-        <para>Related to this, on SUSE Linux Enterprise Server 15 SP2 it would be possible to use
+        <para>Related to this, on SUSE Linux Enterprise Server 15 SP4 it would be possible to use
           the <parameter>haltpoll</parameter> CPU-Idle governor, inside the VM. This is an
-          optimization meant at reducing the number of context switches from the VM and the host
-          (also known as VMExits), when doing static resource partitioning of the host itself. It is
-          would therefore be recommended here, but the problem is that it can be enabled only if the
-          CPU model used is <parameter>host-passthrough</parameter>.</para>
+          optimization meant at reducing the number of context switches between the VM and the host
+          (also known as VMExits), when doing static resource partitioning of the host itself.
+          For that reason, it would be something that we recommend using, the only problem being that it can be enabled only if the CPU model used is <parameter>host-passthrough</parameter>.</para>
 
-        <para>We therefore recommend to not use it in a SUSE Linux Enterprise Server 15 SP2 VM
-          running on an AMD EPYC 7003 Series Processors, until the inaccurate vCPU topology problem
-          is resolved (and an investigation is ongoing for figuring out how to best address the
-          problem).</para>
+        <para>We therefore recommend to not use it in a SUSE Linux Enterprise Server 15 SP4 VM
+          running on an AMD EPYC 9004 Series Processors, until the inaccurate vCPU topology problem when using <parameter>host-passthrough</parameter> is resolved.</para>
 
+        <para>Note that, in order to achieve the outcome shown above, it is very important to use the following CPU topology description string, in the VM configuration:</para>
+
+        <screen>&lt;topology sockets="2" dies="9" cores="8" threads="2"/></screen>
+
+        <para>In particular, do not omit the <parameter>dies="9"</parameter> element, as that is what enables the VM to see its vCPUs grouped in dies, from the point of view of cache layer sharing.
+          In fact, using something like this <parameter>&lt;topology sockets="2" cores="72" threads="2"/></parameter> would result in a correct CPU topology, but the representation of the cache layout would still be inaccurate, such as:</para>
+
+        <screen>
+vm1:~ # lscpu
+...
+CPU(s):                  288
+  On-line CPU(s) list:   0-287
+Vendor ID:               AuthenticAMD
+  Model name:            AMD EPYC-Milan Processor
+    CPU family:          25
+    Model:               1
+    Thread(s) per core:  2
+    Core(s) per socket:  72
+    Socket(s):           2
+...
+Caches (sum of all):
+  L1d:                   4.5 MiB (144 instances)
+  L1i:                   4.5 MiB (144 instances)
+  L2:                    72 MiB (144 instances)
+  L3:                    64 MiB (2 instances)
+...
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-143
+...
+        </screen>
+
+        <para>As a further example, in case we have two VMs, one for each NUMA node and with 192 vCPUs each, both will be configured to have 12 dies (and, of course, just 1 socket), like this:</para>
+
+        <screen>&lt;topology sockets="1" dies="12" cores="8" threads="2"/></screen>
+
+        <para>And the topology, from inside each VM, will look as follows:</para>
+
+        <screen>
+vm1:~ # lscpu
+...
+CPU(s):                  192
+  On-line CPU(s) list:   0-191
+Vendor ID:               AuthenticAMD
+  Model name:            AMD EPYC-Milan Processor
+    CPU family:          25
+    Model:               1
+    Thread(s) per core:  2
+    Core(s) per socket:  96
+    Socket(s):           1
+...
+Caches (sum of all):
+  L1d:                   3 MiB (96 instances)
+  L1i:                   3 MiB (96 instances)
+  L2:                    48 MiB (96 instances)
+  L3:                    384 MiB (12 instances)
+...
+
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-15
+        </screen>
       </sect3>
 
 
@@ -2582,13 +2676,12 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
           never going to be swapped out. This is all achieved as follows: </para>
 
         <screen>
-&lt;memory unit='KiB'>209715200&lt;/memory>
+&lt;memory unit='KiB'>704643072&lt;/memory>
 &lt;memoryBacking>
   &lt;hugepages>
-    &lt;page size='209715200' unit='KiB'/>
+    &lt;page size='1' unit='GiB'/>
   &lt;/hugepages>
   &lt;nosharepages/>
-  &lt;locked/>
 &lt;/memoryBacking>
         </screen>
 
@@ -2611,8 +2704,8 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
           memory ballooning is done as follows: </para>
 
         <screen>
-&lt;memory unit='KiB'>209715200&lt;/memory>
-&lt;currentMemory unit='KiB'>209715200&lt;/currentMemory>
+&lt;memory unit='KiB'>704643072&lt;/memory>
+&lt;currentMemory unit='KiB'>704643072&lt;/currentMemory>
         </screen>
 
         <para> That is, by specifying in the <parameter>&lt;currentMemory></parameter> the same
@@ -2653,7 +2746,7 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
     </sect2>
 
     <sect2 xml:id="sec-sev-vm">
-      <title>Secure Encrypted Virtualization</title>
+      <title>Secure Encrypted Virtualization with Encrypted State</title>
 
       <para>The following documents</para>
       <itemizedlist>
@@ -2666,51 +2759,33 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
         <listitem>
           <para>
             <link
-              xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-amd-sev/art-amd-sev.html"
-              > SUSE Linux Enterprise Server 15 SP2: AMD Secure Encrypted Virtualization (AMD-SEV)
+              xlink:href="https://documentation.suse.com/sles/15-SP4/html/SLES-amd-sev/article-amd-sev.html"
+              > SUSE Linux Enterprise Server 15 SP4: AMD Secure Encrypted Virtualization (AMD-SEV)
               Guide</link>
           </para>
         </listitem>
       </itemizedlist>
-      <para>provide details on how to configure a VM to use AMD SEV (on an AMD SEV capable and
-        properly configured host). Therefore, this section will not go into details. It only lists
-        the entries that are required to add to or change the configuration file. </para>
+      <para>Explain how to configure a VM to use AMD SEV-ES (on an AMD SEV-ES capable and
+        properly configured host) is not in the scope of this document. Refer to the linked materials for the details. </para>
 
-      <para>First of all, a <parameter>&lt;launchSecurity></parameter> stanza must be
-        added:</para>
-
-      <screen>
-&lt;launchSecurity type='sev'>
-  &lt;cbitpos>51&lt;/cbitpos>
-  &lt;reducedPhysBits>1&lt;/reducedPhysBits>
-  &lt;policy>0x0003&lt;/policy>
-&lt;/launchSecurity>
-      </screen>
-
-      <para>Two other things are that the QEMU machine type used for the VM should be
-          <parameter>Q35</parameter> and that a UEFI must be used:</para>
-
-      <screen>
-&lt;os>
-  &lt;type arch='x86_64' machine='pc-q35-3.1'>hvm&lt;/type>
-  &lt;loader readonly='yes' type='pflash'>/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin&lt;/loader>
-  &lt;nvram>/var/lib/libvirt/qemu/nvram/sle15sp1-vm1-sev_VARS.fd&lt;/nvram>
-&lt;/os>
-      </screen>
-
-      <para> Note that on SUSE Linux Enterprise Server 15 SP2, an SEV-enabled VM can use 1 GB Huge
-        Pages memory, preallocated at boot time, the same as when SEV is not enabled as they are
-        allocated during boot.</para>
-
-      <para>Finally, any device that uses <parameter>'virtio'</parameter> needs to gain an XML
-        element looking like: <parameter>&lt;driver iommu='on'/></parameter></para>
-
-      <para>At this point, we can create and start a VM with its memory encrypted, through AMD SEV
-        technology:</para>
+      <para>It is possible to check if the host is properly configured to run SEV-ES VMs with the following command:</para>
 
       <screen>
 dmesg |grep SEV
-[    0.004000] AMD Secure Encrypted Virtualization (SEV) active
+[   32.668559] ccp 0000:02:00.5: SEV API:1.52 build:18
+[   39.219320] SEV supported: 495 ASIDs
+[   39.225083] SEV-ES supported: 511 ASIDs
+      </screen>
+
+      <para> Note that on SUSE Linux Enterprise Server 15 SP4, an SEV-enabled VM can use 1 GB Huge
+        Pages memory, preallocated at boot time, the same as when SEV is not enabled as they are
+        allocated during boot.</para>
+
+      <para>Once inside of the VM, this is how one can check whether the memory and the state are being encrypted with SEV-ES:</para>
+
+      <screen>
+dmesg | grep SEV
+[    0.069436] AMD Memory Encryption Features active: SEV SEV-ES
       </screen>
 
       <bridgehead>SEV and The IOMMU Device</bridgehead>
@@ -2719,12 +2794,12 @@ dmesg |grep SEV
           <parameter>iommu</parameter> element, in the <parameter>&lt;device></parameter>
         section of the VM configuration. Since that element was necessary for having more than 255
         vCPUs in the VM, all the experiments conducted with SEV enabled have been done in VMs with
-        at most 248 vCPUs.</para>
+        at most 224 vCPUs.</para>
 
     </sect2>
 
   </sect1>
-
+<!--
   <sect1 xml:id="sec-virtualization-test-workload-stream">
     <title>Test VM workload: STREAM</title>
 
@@ -3037,309 +3112,48 @@ dmesg |grep SEV
     <screen>
 &lt;domain type="kvm">
   &lt;name>vm1&lt;/name>
-  &lt;uuid>e9afa48f-b359-4389-9ae6-5589240867c0&lt;/uuid>
   &lt;metadata>
     &lt;libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
-      &lt;libosinfo:os id="http://suse.com/sle/15.2"/>
+      &lt;libosinfo:os id="http://suse.com/sle/15.4"/>
     &lt;/libosinfo:libosinfo>
   &lt;/metadata>
-  &lt;memory unit="KiB">209715200&lt;/memory>
-  &lt;currentMemory unit="KiB">209715200&lt;/currentMemory>
+  &lt;memory unit="KiB">704643072&lt;/memory>
+  &lt;currentMemory unit="KiB">704643072&lt;/currentMemory>
   &lt;memoryBacking>
     &lt;hugepages>
       &lt;page size="1048576" unit="KiB"/>
     &lt;/hugepages>
     &lt;nosharepages/>
-    &lt;locked/>
   &lt;/memoryBacking>
-  &lt;vcpu placement="static">256&lt;/vcpu>
+  &lt;vcpu placement="static">288&lt;/vcpu>
   &lt;cputune>
-    &lt;vcpupin vcpu="0" cpuset="0"/>
-    &lt;vcpupin vcpu="1" cpuset="128"/>
-    &lt;vcpupin vcpu="2" cpuset="1"/>
-    &lt;vcpupin vcpu="3" cpuset="129"/>
-    &lt;vcpupin vcpu="4" cpuset="2"/>
-    &lt;vcpupin vcpu="5" cpuset="130"/>
-    &lt;vcpupin vcpu="6" cpuset="3"/>
-    &lt;vcpupin vcpu="7" cpuset="131"/>
-    &lt;vcpupin vcpu="8" cpuset="4"/>
-    &lt;vcpupin vcpu="9" cpuset="132"/>
-    &lt;vcpupin vcpu="10" cpuset="5"/>
-    &lt;vcpupin vcpu="11" cpuset="133"/>
-    &lt;vcpupin vcpu="12" cpuset="6"/>
-    &lt;vcpupin vcpu="13" cpuset="134"/>
-    &lt;vcpupin vcpu="14" cpuset="7"/>
-    &lt;vcpupin vcpu="15" cpuset="135"/>
-    &lt;vcpupin vcpu="16" cpuset="8"/>
-    &lt;vcpupin vcpu="17" cpuset="136"/>
-    &lt;vcpupin vcpu="18" cpuset="9"/>
-    &lt;vcpupin vcpu="19" cpuset="137"/>
-    &lt;vcpupin vcpu="20" cpuset="10"/>
-    &lt;vcpupin vcpu="21" cpuset="138"/>
-    &lt;vcpupin vcpu="22" cpuset="11"/>
-    &lt;vcpupin vcpu="23" cpuset="139"/>
-    &lt;vcpupin vcpu="24" cpuset="12"/>
-    &lt;vcpupin vcpu="25" cpuset="140"/>
-    &lt;vcpupin vcpu="26" cpuset="13"/>
-    &lt;vcpupin vcpu="27" cpuset="141"/>
-    &lt;vcpupin vcpu="28" cpuset="14"/>
-    &lt;vcpupin vcpu="29" cpuset="142"/>
-    &lt;vcpupin vcpu="30" cpuset="15"/>
-    &lt;vcpupin vcpu="31" cpuset="143"/>
-    &lt;vcpupin vcpu="32" cpuset="16"/>
-    &lt;vcpupin vcpu="33" cpuset="144"/>
-    &lt;vcpupin vcpu="34" cpuset="17"/>
-    &lt;vcpupin vcpu="35" cpuset="145"/>
-    &lt;vcpupin vcpu="36" cpuset="18"/>
-    &lt;vcpupin vcpu="37" cpuset="146"/>
-    &lt;vcpupin vcpu="38" cpuset="19"/>
-    &lt;vcpupin vcpu="39" cpuset="147"/>
-    &lt;vcpupin vcpu="40" cpuset="20"/>
-    &lt;vcpupin vcpu="41" cpuset="148"/>
-    &lt;vcpupin vcpu="42" cpuset="21"/>
-    &lt;vcpupin vcpu="43" cpuset="149"/>
-    &lt;vcpupin vcpu="44" cpuset="22"/>
-    &lt;vcpupin vcpu="45" cpuset="150"/>
-    &lt;vcpupin vcpu="46" cpuset="23"/>
-    &lt;vcpupin vcpu="47" cpuset="151"/>
-    &lt;vcpupin vcpu="48" cpuset="24"/>
-    &lt;vcpupin vcpu="49" cpuset="152"/>
-    &lt;vcpupin vcpu="50" cpuset="25"/>
-    &lt;vcpupin vcpu="51" cpuset="153"/>
-    &lt;vcpupin vcpu="52" cpuset="26"/>
-    &lt;vcpupin vcpu="53" cpuset="154"/>
-    &lt;vcpupin vcpu="54" cpuset="27"/>
-    &lt;vcpupin vcpu="55" cpuset="155"/>
-    &lt;vcpupin vcpu="56" cpuset="28"/>
-    &lt;vcpupin vcpu="57" cpuset="156"/>
-    &lt;vcpupin vcpu="58" cpuset="29"/>
-    &lt;vcpupin vcpu="59" cpuset="157"/>
-    &lt;vcpupin vcpu="60" cpuset="30"/>
-    &lt;vcpupin vcpu="61" cpuset="158"/>
-    &lt;vcpupin vcpu="62" cpuset="31"/>
-    &lt;vcpupin vcpu="63" cpuset="159"/>
-    &lt;vcpupin vcpu="64" cpuset="32"/>
-    &lt;vcpupin vcpu="65" cpuset="160"/>
-    &lt;vcpupin vcpu="66" cpuset="33"/>
-    &lt;vcpupin vcpu="67" cpuset="161"/>
-    &lt;vcpupin vcpu="68" cpuset="34"/>
-    &lt;vcpupin vcpu="69" cpuset="162"/>
-    &lt;vcpupin vcpu="70" cpuset="35"/>
-    &lt;vcpupin vcpu="71" cpuset="163"/>
-    &lt;vcpupin vcpu="72" cpuset="36"/>
-    &lt;vcpupin vcpu="73" cpuset="164"/>
-    &lt;vcpupin vcpu="74" cpuset="37"/>
-    &lt;vcpupin vcpu="75" cpuset="165"/>
-    &lt;vcpupin vcpu="76" cpuset="38"/>
-    &lt;vcpupin vcpu="77" cpuset="166"/>
-    &lt;vcpupin vcpu="78" cpuset="39"/>
-    &lt;vcpupin vcpu="79" cpuset="167"/>
-    &lt;vcpupin vcpu="80" cpuset="40"/>
-    &lt;vcpupin vcpu="81" cpuset="168"/>
-    &lt;vcpupin vcpu="82" cpuset="41"/>
-    &lt;vcpupin vcpu="83" cpuset="169"/>
-    &lt;vcpupin vcpu="84" cpuset="42"/>
-    &lt;vcpupin vcpu="85" cpuset="170"/>
-    &lt;vcpupin vcpu="86" cpuset="43"/>
-    &lt;vcpupin vcpu="87" cpuset="171"/>
-    &lt;vcpupin vcpu="88" cpuset="44"/>
-    &lt;vcpupin vcpu="89" cpuset="172"/>
-    &lt;vcpupin vcpu="90" cpuset="45"/>
-    &lt;vcpupin vcpu="91" cpuset="173"/>
-    &lt;vcpupin vcpu="92" cpuset="46"/>
-    &lt;vcpupin vcpu="93" cpuset="174"/>
-    &lt;vcpupin vcpu="94" cpuset="47"/>
-    &lt;vcpupin vcpu="95" cpuset="175"/>
-    &lt;vcpupin vcpu="96" cpuset="48"/>
-    &lt;vcpupin vcpu="97" cpuset="176"/>
-    &lt;vcpupin vcpu="98" cpuset="49"/>
-    &lt;vcpupin vcpu="99" cpuset="177"/>
-    &lt;vcpupin vcpu="100" cpuset="50"/>
-    &lt;vcpupin vcpu="101" cpuset="178"/>
-    &lt;vcpupin vcpu="102" cpuset="51"/>
-    &lt;vcpupin vcpu="103" cpuset="179"/>
-    &lt;vcpupin vcpu="104" cpuset="52"/>
-    &lt;vcpupin vcpu="105" cpuset="180"/>
-    &lt;vcpupin vcpu="106" cpuset="53"/>
-    &lt;vcpupin vcpu="107" cpuset="181"/>
-    &lt;vcpupin vcpu="108" cpuset="54"/>
-    &lt;vcpupin vcpu="109" cpuset="182"/>
-    &lt;vcpupin vcpu="110" cpuset="55"/>
-    &lt;vcpupin vcpu="111" cpuset="183"/>
-    &lt;vcpupin vcpu="112" cpuset="56"/>
-    &lt;vcpupin vcpu="113" cpuset="184"/>
-    &lt;vcpupin vcpu="114" cpuset="57"/>
-    &lt;vcpupin vcpu="115" cpuset="185"/>
-    &lt;vcpupin vcpu="116" cpuset="58"/>
-    &lt;vcpupin vcpu="117" cpuset="186"/>
-    &lt;vcpupin vcpu="118" cpuset="59"/>
-    &lt;vcpupin vcpu="119" cpuset="187"/>
-    &lt;vcpupin vcpu="120" cpuset="60"/>
-    &lt;vcpupin vcpu="121" cpuset="188"/>
-    &lt;vcpupin vcpu="122" cpuset="61"/>
-    &lt;vcpupin vcpu="123" cpuset="189"/>
-    &lt;vcpupin vcpu="124" cpuset="62"/>
-    &lt;vcpupin vcpu="125" cpuset="190"/>
-    &lt;vcpupin vcpu="126" cpuset="63"/>
-    &lt;vcpupin vcpu="127" cpuset="191"/>
-    &lt;vcpupin vcpu="128" cpuset="64"/>
-    &lt;vcpupin vcpu="129" cpuset="192"/>
-    &lt;vcpupin vcpu="130" cpuset="65"/>
-    &lt;vcpupin vcpu="131" cpuset="193"/>
-    &lt;vcpupin vcpu="132" cpuset="66"/>
-    &lt;vcpupin vcpu="133" cpuset="194"/>
-    &lt;vcpupin vcpu="134" cpuset="67"/>
-    &lt;vcpupin vcpu="135" cpuset="195"/>
-    &lt;vcpupin vcpu="136" cpuset="68"/>
-    &lt;vcpupin vcpu="137" cpuset="196"/>
-    &lt;vcpupin vcpu="138" cpuset="69"/>
-    &lt;vcpupin vcpu="139" cpuset="197"/>
-    &lt;vcpupin vcpu="140" cpuset="70"/>
-    &lt;vcpupin vcpu="141" cpuset="198"/>
-    &lt;vcpupin vcpu="142" cpuset="71"/>
-    &lt;vcpupin vcpu="143" cpuset="199"/>
-    &lt;vcpupin vcpu="144" cpuset="72"/>
-    &lt;vcpupin vcpu="145" cpuset="200"/>
-    &lt;vcpupin vcpu="146" cpuset="73"/>
-    &lt;vcpupin vcpu="147" cpuset="201"/>
-    &lt;vcpupin vcpu="148" cpuset="74"/>
-    &lt;vcpupin vcpu="149" cpuset="202"/>
-    &lt;vcpupin vcpu="150" cpuset="75"/>
-    &lt;vcpupin vcpu="151" cpuset="203"/>
-    &lt;vcpupin vcpu="152" cpuset="76"/>
-    &lt;vcpupin vcpu="153" cpuset="204"/>
-    &lt;vcpupin vcpu="154" cpuset="77"/>
-    &lt;vcpupin vcpu="155" cpuset="205"/>
-    &lt;vcpupin vcpu="156" cpuset="78"/>
-    &lt;vcpupin vcpu="157" cpuset="206"/>
-    &lt;vcpupin vcpu="158" cpuset="79"/>
-    &lt;vcpupin vcpu="159" cpuset="207"/>
-    &lt;vcpupin vcpu="160" cpuset="80"/>
-    &lt;vcpupin vcpu="161" cpuset="208"/>
-    &lt;vcpupin vcpu="162" cpuset="81"/>
-    &lt;vcpupin vcpu="163" cpuset="209"/>
-    &lt;vcpupin vcpu="164" cpuset="82"/>
-    &lt;vcpupin vcpu="165" cpuset="210"/>
-    &lt;vcpupin vcpu="166" cpuset="83"/>
-    &lt;vcpupin vcpu="167" cpuset="211"/>
-    &lt;vcpupin vcpu="168" cpuset="84"/>
-    &lt;vcpupin vcpu="169" cpuset="212"/>
-    &lt;vcpupin vcpu="170" cpuset="85"/>
-    &lt;vcpupin vcpu="171" cpuset="213"/>
-    &lt;vcpupin vcpu="172" cpuset="86"/>
-    &lt;vcpupin vcpu="173" cpuset="214"/>
-    &lt;vcpupin vcpu="174" cpuset="87"/>
-    &lt;vcpupin vcpu="175" cpuset="215"/>
-    &lt;vcpupin vcpu="176" cpuset="88"/>
-    &lt;vcpupin vcpu="177" cpuset="216"/>
-    &lt;vcpupin vcpu="178" cpuset="89"/>
-    &lt;vcpupin vcpu="179" cpuset="217"/>
-    &lt;vcpupin vcpu="180" cpuset="90"/>
-    &lt;vcpupin vcpu="181" cpuset="218"/>
-    &lt;vcpupin vcpu="182" cpuset="91"/>
-    &lt;vcpupin vcpu="183" cpuset="219"/>
-    &lt;vcpupin vcpu="184" cpuset="92"/>
-    &lt;vcpupin vcpu="185" cpuset="220"/>
-    &lt;vcpupin vcpu="186" cpuset="93"/>
-    &lt;vcpupin vcpu="187" cpuset="221"/>
-    &lt;vcpupin vcpu="188" cpuset="94"/>
-    &lt;vcpupin vcpu="189" cpuset="222"/>
-    &lt;vcpupin vcpu="190" cpuset="95"/>
-    &lt;vcpupin vcpu="191" cpuset="223"/>
-    &lt;vcpupin vcpu="192" cpuset="96"/>
-    &lt;vcpupin vcpu="193" cpuset="224"/>
-    &lt;vcpupin vcpu="194" cpuset="97"/>
-    &lt;vcpupin vcpu="195" cpuset="225"/>
-    &lt;vcpupin vcpu="196" cpuset="98"/>
-    &lt;vcpupin vcpu="197" cpuset="226"/>
-    &lt;vcpupin vcpu="198" cpuset="99"/>
-    &lt;vcpupin vcpu="199" cpuset="227"/>
-    &lt;vcpupin vcpu="200" cpuset="100"/>
-    &lt;vcpupin vcpu="201" cpuset="228"/>
-    &lt;vcpupin vcpu="202" cpuset="101"/>
-    &lt;vcpupin vcpu="203" cpuset="229"/>
-    &lt;vcpupin vcpu="204" cpuset="102"/>
-    &lt;vcpupin vcpu="205" cpuset="230"/>
-    &lt;vcpupin vcpu="206" cpuset="103"/>
-    &lt;vcpupin vcpu="207" cpuset="231"/>
-    &lt;vcpupin vcpu="208" cpuset="104"/>
-    &lt;vcpupin vcpu="209" cpuset="232"/>
-    &lt;vcpupin vcpu="210" cpuset="105"/>
-    &lt;vcpupin vcpu="211" cpuset="233"/>
-    &lt;vcpupin vcpu="212" cpuset="106"/>
-    &lt;vcpupin vcpu="213" cpuset="234"/>
-    &lt;vcpupin vcpu="214" cpuset="107"/>
-    &lt;vcpupin vcpu="215" cpuset="235"/>
-    &lt;vcpupin vcpu="216" cpuset="108"/>
-    &lt;vcpupin vcpu="217" cpuset="236"/>
-    &lt;vcpupin vcpu="218" cpuset="109"/>
-    &lt;vcpupin vcpu="219" cpuset="237"/>
-    &lt;vcpupin vcpu="220" cpuset="110"/>
-    &lt;vcpupin vcpu="221" cpuset="238"/>
-    &lt;vcpupin vcpu="222" cpuset="111"/>
-    &lt;vcpupin vcpu="223" cpuset="239"/>
-    &lt;vcpupin vcpu="224" cpuset="112"/>
-    &lt;vcpupin vcpu="225" cpuset="240"/>
-    &lt;vcpupin vcpu="226" cpuset="113"/>
-    &lt;vcpupin vcpu="227" cpuset="241"/>
-    &lt;vcpupin vcpu="228" cpuset="114"/>
-    &lt;vcpupin vcpu="229" cpuset="242"/>
-    &lt;vcpupin vcpu="230" cpuset="115"/>
-    &lt;vcpupin vcpu="231" cpuset="243"/>
-    &lt;vcpupin vcpu="232" cpuset="116"/>
-    &lt;vcpupin vcpu="233" cpuset="244"/>
-    &lt;vcpupin vcpu="234" cpuset="117"/>
-    &lt;vcpupin vcpu="235" cpuset="245"/>
-    &lt;vcpupin vcpu="236" cpuset="118"/>
-    &lt;vcpupin vcpu="237" cpuset="246"/>
-    &lt;vcpupin vcpu="238" cpuset="119"/>
-    &lt;vcpupin vcpu="239" cpuset="247"/>
-    &lt;vcpupin vcpu="240" cpuset="120"/>
-    &lt;vcpupin vcpu="241" cpuset="248"/>
-    &lt;vcpupin vcpu="242" cpuset="121"/>
-    &lt;vcpupin vcpu="243" cpuset="249"/>
-    &lt;vcpupin vcpu="244" cpuset="122"/>
-    &lt;vcpupin vcpu="245" cpuset="250"/>
-    &lt;vcpupin vcpu="246" cpuset="123"/>
-    &lt;vcpupin vcpu="247" cpuset="251"/>
-    &lt;vcpupin vcpu="248" cpuset="124"/>
-    &lt;vcpupin vcpu="249" cpuset="252"/>
-    &lt;vcpupin vcpu="250" cpuset="125"/>
-    &lt;vcpupin vcpu="251" cpuset="253"/>
-    &lt;vcpupin vcpu="252" cpuset="126"/>
-    &lt;vcpupin vcpu="253" cpuset="254"/>
-    &lt;vcpupin vcpu="254" cpuset="127"/>
-    &lt;vcpupin vcpu="255" cpuset="255"/>
+TODO
   &lt;/cputune>
   &lt;numatune>
     &lt;memory mode="strict" nodeset="0-1"/>
     &lt;memnode cellid="0" mode="strict" nodeset="0"/>
     &lt;memnode cellid="1" mode="strict" nodeset="1"/>
   &lt;/numatune>
-  &lt;os>
-    &lt;type arch="x86_64" machine="pc-q35-4.2">hvm&lt;/type>
-    &lt;loader readonly="yes" type="pflash">/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin&lt;/loader>
-    &lt;nvram>/var/lib/libvirt/qemu/nvram/vm1_VARS.fd&lt;/nvram>
+  &lt;os firmware="efi">
+    &lt;type arch="x86_64" machine="pc-q35-6.2">hvm&lt;/type>
     &lt;boot dev="hd"/>
   &lt;/os>
   &lt;features>
     &lt;acpi/>
     &lt;apic/>
-    &lt;pae/>
     &lt;vmport state="off"/>
     &lt;ioapic driver="qemu"/>
   &lt;/features>
-  &lt;cpu mode="custom" match="exact" check="none">
-    &lt;model fallback="allow">EPYC&lt;/model>
-    &lt;topology sockets="2" cores="64" threads="2"/>
+  &lt;cpu mode="host-model" check="none">
+    &lt;topology sockets="2" dies="9" cores="8" threads="2"/>
     &lt;numa>
-      &lt;cell id="0" cpus="0-127" memory="104857600" unit="KiB">
+      &lt;cell id="0" cpus="0-143" memory="352321536" unit="KiB">
         &lt;distances>
           &lt;sibling id="0" value="10"/>
           &lt;sibling id="1" value="32"/>
         &lt;/distances>
       &lt;/cell>
-      &lt;cell id="1" cpus="128-255" memory="104857600" unit="KiB">
+      &lt;cell id="1" cpus="144-287" memory="352321536" unit="KiB">
         &lt;distances>
           &lt;sibling id="0" value="32"/>
           &lt;sibling id="1" value="10"/>
@@ -3362,49 +3176,26 @@ dmesg |grep SEV
   &lt;devices>
     &lt;emulator>/usr/bin/qemu-system-x86_64&lt;/emulator>
     &lt;disk type="file" device="disk">
-      &lt;driver name="qemu" type="qcow2"/>
+      &lt;driver name="qemu" type="qcow2" discard="unmap"/>
       &lt;source file="/var/lib/libvirt/images/vm1.qcow2"/>
       &lt;target dev="vda" bus="virtio"/>
-      &lt;address type="pci" domain="0x0000" bus="0x05" slot="0x00" function="0x0"/>
     &lt;/disk>
     ...
     &lt;interface type="network">
       &lt;mac address="52:54:00:16:1e:01"/>
       &lt;source network="default"/>
       &lt;model type="virtio"/>
-      &lt;rom enabled="no"/>
-      &lt;address type="pci" domain="0x0000" bus="0x01" slot="0x00" function="0x0"/>
     &lt;/interface>
-    &lt;serial type="pty">
-      &lt;target type="isa-serial" port="0">
-        &lt;model name="isa-serial"/>
-      &lt;/target>
-    &lt;/serial>
-    &lt;console type="pty">
-      &lt;target type="serial" port="0"/>
-    &lt;/console>
     ...
-    &lt;graphics type="spice" autoport="yes">
-      &lt;listen type="address"/>
-    &lt;/graphics>
-    &lt;video>
-      &lt;model type="qxl" ram="65536" vram="65536" vgamem="16384" heads="1" primary="yes"/>
-      &lt;address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0"/>
-    &lt;/video>
-    &lt;memballoon model="virtio">
-      &lt;address type="pci" domain="0x0000" bus="0x06" slot="0x00" function="0x0"/>
-    &lt;/memballoon>
     &lt;rng model="virtio">
       &lt;backend model="random">/dev/urandom&lt;/backend>
-      &lt;address type="pci" domain="0x0000" bus="0x08" slot="0x00" function="0x0"/>
     &lt;/rng>
+    &lt;tpm model="tpm-crb">
+      &lt;backend type="emulator" version="2.0"/>
+    &lt;/tpm>
     &lt;iommu model="intel">
       &lt;driver intremap="on" eim="on"/>
     &lt;/iommu>
-    &lt;vsock model="virtio">
-      &lt;cid auto="yes"/>
-      &lt;address type="pci" domain="0x0000" bus="0x07" slot="0x00" function="0x0"/>
-    &lt;/vsock>
   &lt;/devices>
 &lt;/domain>
     </screen>

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -65,7 +65,7 @@
       <author>
         <personname>
           <firstname>Dario</firstname>
-	  <surname>Faggioli</surname>
+	        <surname>Faggioli</surname>
         </personname>
         <affiliation>
           <jobtitle>Virtualization Specialist</jobtitle>
@@ -1847,7 +1847,7 @@ epyc:~ # perf script
 
         <para> When using KVM, sparing, for example, 24 cores (i.e., one full core for each CCX on both NUMA nodes) and 64 GB of RAM for the host OS is
           done by stopping creating VMs when the total number of vCPUs of all VMs has reached 336
-          (as each core has 2 threads) or when the total cumulative amount of allocated RAM has
+          (as each core has 2 threads) and when the total cumulative amount of allocated RAM has
           reached 690 GB. </para>
 
         <para> To make sure that these CPUs are not used by the virtual machines and are available
@@ -2016,9 +2016,9 @@ epyc:~ # perf script
     <sect2 xml:id="sec-sev-host">
       <title>Secure Encrypted Virtualization (SEV)</title>
 
-      <para> Secure Encrypted Virtualization, with Encrypted State (SEV-ES) technology, supported on the 4rd Generation AMD
-        EPYC Processors, allows the memory of the VMs to be encrypted. It enables an even greater level of
-        confidentiality, as compared to plain SEV, supported in the previous generation of the processor
+      <para> Secure Encrypted Virtualization (SEV) and SEV with Encrypted State (SEV-ES) technologies, are available on the 5th Generation AMD
+        EPYC Processors when SUSE Linux Enterprise Server 15 SP4 is used both as an host and guest OS. They allow the memory of the VMs to be encrypted, enabling an high level of
+        confidentiality. SEV-ES is considered superior to plain SEV, as also CPU registers are encrypted when they are saved into the host memory.
         For using SEV-ES for a VM, we need to enable it in the VM's own configuration file, but there are preparation steps that needs to occur at
         the host level. </para>
 
@@ -2038,10 +2038,9 @@ epyc:~ # perf script
         parameters above added to the host kernel boot command line, resulted in indistinguishable
         results. Therefore, enabling SEV-ES at the host level can be considered safe, from the point of
         view of not hurting performance of VMs and workloads that will not take advantage of VM memory
-        encryption. Of course, this applies to when SEV-ES is enabled for the host and is
-          <emphasis>not</emphasis> used for encrypting VMs. </para>
+        encryption. </para>
 
-      <para>What happens when SEV-ES is used for encrypting VMs' memory will be described later in the
+      <para>On the other hand, what happens when SEV and SEV-ES are used for encrypting VMs' memory is described later in the
         guide.</para>
 
       <note>
@@ -2111,7 +2110,7 @@ epyc:~ # perf script
       </screen>
 
       <para> The <parameter>'strict'</parameter> guarantees that the all memory for the VM will come
-        only from the specified (set of) NUMA node(s) specified in <parameter>nodeset</parameter>. A
+        only from the (set of) NUMA node(s) specified in <parameter>nodeset</parameter>. A
         cell is, in fact, a virtual NUMA node, with <parameter>cellid</parameter> being its ID and
           <parameter>nodeset</parameter> telling exactly from what host physical NUMA node(s) the
         memory for this virtual node should be allocated.</para>
@@ -2137,13 +2136,13 @@ Total                   344213.59       348737.54       692951.12
         1 VM running) and its memory footprint has been equally split between the
         two NUMA nodes.</para>
 
-      <para>A NUMA-unaware VMs can still include this
+      <para>A NUMA-unaware VM can still include this
         element in its configuration file. It will have only one
           <parameter>&lt;memnode></parameter> element, and the output of
         <parameter>numastat</parameter> will look like this:</para>
 
       <screen>
-deandre:/abuild/:[0]# numastat -p qemu-system-x86_64
+host:~ # numastat -p qemu-system-x86_64
 Per-node process memory usage (in MBs)
 PID                               Node 0          Node 1           Total
 -----------------------  --------------- --------------- ---------------
@@ -2204,7 +2203,7 @@ Total                          346060.48       346246.34       692306.82
         siblings will always execute on actual physical SMT siblings. </para>
 
       <para> The following sections give more specific and precise details about placement of vCPUs
-        and memory for VM of varying sizes of VMs, on the reference system for this guide (see <xref
+        and memory for VM of varying sizes, on the reference system for this guide (see <xref
           linkend="fig-epyc-topology"/>. </para>
 
      <para>Note that, despite the fact that the server has 384 pCPUs, a VM in SUSE Linux Enterprise
@@ -2215,7 +2214,7 @@ Total                          346060.48       346246.34       692306.82
       <sect3 xml:id="sec-placement-one-vm">
         <title>Placement of a single large VM</title>
 
-        <para> An interesting use case when <quote>only one</quote> VM is used. Reasons for doing
+        <para> An interesting use case is when <quote>only one</quote> VM is used. Reasons for doing
           something like that include security/isolation, flexibility, high availability, and
           others. In this cases, typically, the VM is almost as large as the host itself. </para>
 
@@ -2227,11 +2226,13 @@ Total                          346060.48       346246.34       692306.82
           there are physical NUMA nodes), and split the VM’s memory equally among them. The 672
           vCPUs are assigned to the 2 nodes, 336 on each. </para>
 
-        <para> The VM Memory must be split equally among the 2 nodes. At this point, if a suitable
+        <para> We should create a virtual topology with 2 virtual NUMA nodes (that is, as many as
+          there are physical NUMA nodes), and split the VM’s memory equally among them. The 672
+          vCPUs are assigned to the 2 nodes, 336 on each. This way, if a suitable
           virtual topology is also provided to the VM, each of the VM’s vCPUs will access its own
           memory directly, and use Infinity Fabric inter-socket links only to reach foreign memory,
           as it happens on the host. Workloads running inside the VM can be tuned exactly like they
-          were running on a bare metal 3rd Generation AMD EPYC Processor server. </para>
+          were running on a bare metal 4th Generation AMD EPYC Processor server. </para>
 
         <para>The following example <command>numactl</command> output comes from a VM configured as
           explained:</para>
@@ -2256,8 +2257,7 @@ node   0   1
           Server 15 SP4 allows us to define the virtual nodes distance table). The only differences
           are the number of CPUs, their APIC IDs and the amount of memory. </para>
 
-        <para>See <xref linkend="sec-appendix-a"/> for an almost complete VM configuration
-          file.</para>
+        <para>See <xref linkend="sec-appendix-a"/> for a complete VM configuration file.</para>
 
         <para>As said already, full cores must always be used. If possible always fully use CCXes/dies too.
           Since each die has 16 CPUs, that means that a VM with 288 vCPUs will use 9 CCXes on each of the 2 nodes
@@ -2265,7 +2265,7 @@ node   0   1
           So, for instance, vCPUs 0 to 15 can be assigned to Cores L#0 to L#7 (and hence to CPUs P#0 to P#7 and P#192 to P#199), on node P#0;
           vCPUs 16 to 31 to Cores L#$8 to L#15, and so on. No vCPU will be pinned, on the other hand, on Cores L#72 to L#95.
           And the same on node P#1.
-          This guarantees that there will be no interference between the VM and the host via the L3 cache that the CPUs of each die share.</para>
+          In fact, this is what we call coherent 1-to-1 mapping between virtual and physical topologies.</para>
 
       </sect3>
 
@@ -2302,14 +2302,13 @@ node   0
           64 vCPUs and up to 112 GB of RAM each, 12 VMs with 32 vCPUs and 56 GB RAM, or even
           24 VMs, all with 16 vCPUs and 28 GB RAM.</para>
 
-        <para>In the first case, each VM will span 6 host dies. In the third and in the second,
-          to 4 and 2 dies.
-          In the third one, each VM will be pinned to 1 die.</para>
+        <para>In the first case, each VM will span 6 host dies. In the second and third cases, 4 and 2 dies.
+          While in the fourth one, each VM will be pinned to 1 die.</para>
 
-        <para> In all these cases, VMs do not need to be placed across the host NUMA nodes
+        <para> In all these situations, VMs do not need to (and, therefore, should not) be placed across the host NUMA nodes
           boundary, and hence they do not need to be NUMA-aware. They still benefit from having a
           virtual topology, in terms of cores, threads and dies which matches the resource they are
-          using. You will find more details about this in following sections. </para>
+          using (discussed in more details about in the following section). </para>
 
       </sect3>
 
@@ -2345,7 +2344,8 @@ node   0
           recommended to still not go beyond 192, and assign no less than one full core to each VM.
           It should be avoided to have vCPUs from different VMs running on two siblings threads of
           the same core. Such a solution, although functional, is not ideal for all the cases where
-          good and consistent performance within VMs is a goal. What can be done for each VM and for
+          good and consistent performance within VMs is a goal (as well as for security concerns, but that is out of the scope of this guide).
+          What can be done for each VM and for
           each core is to use one of the two threads for the actual vCPU, and the other for its IO
           thread(s), on the host. This solution allows to take advantage of the full 4th Generation
           AMD EPYC processing power. However, we advise to check and verify whether this is a good
@@ -2680,18 +2680,19 @@ vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
 
         <para>Finally, on SUSE Linux Enterprise Server 15 SP4 it is possible to select
           the <parameter>haltpoll</parameter> CPU-Idle governor, inside the VM, even if we are using <parameter>model='host-model'</parameter>
-          (although, it would will be only partially effective, as it would require <parameter>model='host-passthourgh'</parameter>
-          in order for the VM to be able to exploit its full potential). In order to enable that, it is enough to load the
-          kernel module (inside of the VM, of course): </para>
+          (although, it is only partially effective, as <parameter>model='host-passthourgh'</parameter> would be necessary
+          in order for the VM to be able to exploit this feature at its full potential).</para>
+
+        <para>This is an optimization meant at reducing the number of context switches between the VM and the host
+          (also known as VMExits), when doing static resource partitioning of the host itself.
+          For that reason, it is something that we recommend using, although the actual benefit provides highly
+          depends on the workload running inside of the VM.</para>
+
+        <para>For enabling it, just load the kernel module (inside of the VM, of course): </para>
 
         <screen>
 vm1:~ # modprobe cpuidle-haltpoll
         </screen>
-
-        <para>This is an optimization meant at reducing the number of context switches between the VM and the host
-          (also known as VMExits), when doing static resource partitioning of the host itself.
-          For that reason, it is something that we recommend using. Beware, however, that the actual benefit it
-          will provide highly depends on the workload running inside of the VM.</para>
 
       </sect3>
 
@@ -2699,7 +2700,7 @@ vm1:~ # modprobe cpuidle-haltpoll
       <sect3 xml:id="sec-memory-backing">
         <title>Memory backing</title>
 
-        <para> Memory wise, the VMs need to be told to use the Huge Pages that were reserved for
+        <para> Memory wise, the VMs must be told to use the Huge Pages that were reserved for
           them. To effectively use 1 GB huge pages, the amount of memory each VM is given must be a
           multiple of 1 GB. Also, KSM should be disabled and we also must ensure that VMs' memory is
           never going to be swapped out. This is all achieved as follows:</para>
@@ -2734,7 +2735,7 @@ Hugetlb:        704643072 kB
         <note>
           <title>Huge Pages, shared pages and locked pages on Xen</title>
           <para> On Xen, for HVM guests, huge pages are used by default and there is neither any
-            page sharing nor swapping (at least not in SUSE Linux Enterprise Server 15 SP1).
+            page sharing nor swapping (at least not in SUSE Linux Enterprise Server 15 SP4).
             Therefore, the entire <parameter>&lt;memoryBacking></parameter> element is
             technically not necessary. </para>
         </note>
@@ -2823,17 +2824,14 @@ dmesg |grep SEV
 [   39.225083] SEV-ES supported: 511 ASIDs
       </screen>
 
-      <para> Note that on SUSE Linux Enterprise Server 15 SP4, an SEV-enabled VM can use 1 GB Huge
-        Pages memory, preallocated at boot time..</para>
-
-      <para>Once inside of the VM, this is how one can check whether the memory and the state are being encrypted only with SEV:</para>
+      <para>Once inside of the VM, this is how one can check whether it is only the memory that is being encrypted (with SEV):</para>
 
       <screen>
 dmesg | grep SEV
 [    0.069436] AMD Memory Encryption Features active: SEV
       </screen>
 
-      <para>Or if we are also fully encrypting the VM state with SEV-ES:</para>
+      <para>Or if we are also fully encrypting the VM state (with SEV-ES):</para>
 
       <screen>
 dmesg | grep SEV
@@ -2958,7 +2956,7 @@ dmesg | grep SEV
       <title>Test scenario: Multiple VMs</title>
 
       <para>
-        <xref linkend="fig-stream-single-vms-avg"/> and <xref linkend="fig-stream-single-vms-sum"/> show what happens when 1, 2, 4, 6, 12 or 24 VMs are used.
+        <xref linkend="fig-stream-single-vms-avg"/> and <xref linkend="fig-stream-single-vms-sum"/> show what happens when 1, 2, 4, 6, 12 and 24 VMs are used.
         The former reports the average bandwidth achieved in each experiments, considering all the VMs involved. For example, the yellow blue bar (4 VMS) is relative to an
         experiment where 4 VMs were concurrently running the STREAM benchmark (in single thread mode) and represents the average of the 4 different memory bandwidth values,
         one for each of such VMs.
@@ -3157,7 +3155,6 @@ dmesg | grep SEV
       </para>
 
     </sect2>
-
   </sect1>
 
   <sect1 xml:id="sec-conclusion">

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -2840,9 +2840,10 @@ dmesg | grep SEV
 
       <bridgehead>SEV and The IOMMU Device</bridgehead>
 
-      <para>In our experiments, for having a functional VM with SEV enabled, we had to remove the
+      <para>Note that it is not possible to provide a virtual IOMMU device to an encrypted VM.
+        This means that, for having a functional SEV or SEV-ES VM, we need to remove the
           <parameter>iommu</parameter> element, in the <parameter>&lt;device></parameter>
-        section of the VM configuration. Since that element was necessary for having more than 255
+        section of the VM configuration. And since that element is necessary for having more than 255
         vCPUs in the VM, all the experiments conducted with SEV enabled have been done in VMs with
         at most 192 vCPUs.</para>
 

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -2869,10 +2869,10 @@ dmesg | grep SEV
         <title>STREAM Bandwidth - Bare metal compared with one VM</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="EPYC4-stream-bm-1vm.png" width="80%" format="SVG"/>
+            <imagedata fileref="EPYC4-stream-bm-1vm.svg" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="EPYC4-stream-bm-1vm.png" width="80%" format="SVG"/>
+            <imagedata fileref="EPYC4-stream-bm-1vm.svg" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
@@ -2921,10 +2921,10 @@ dmesg | grep SEV
         <title>STREAM Bandwidth - Single thread in one VM with different CPU models</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="EPYC4-stream-single-1vm-model.png" width="80%" format="SVG"/>
+            <imagedata fileref="EPYC4-stream-single-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="EPYC4-stream-single-1vm-model.png" width="80%" format="SVG"/>
+            <imagedata fileref="EPYC4-stream-single-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
@@ -2933,10 +2933,10 @@ dmesg | grep SEV
         <title>STREAM Bandwidth - OpenMP in one VM with different CPU models</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="EPYC4-stream-omp-1vm-model.png" width="80%" format="SVG"/>
+            <imagedata fileref="EPYC4-stream-omp-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="EPYC4-stream-omp-1vm-model.png" width="80%" format="SVG"/>
+            <imagedata fileref="EPYC4-stream-omp-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -2681,8 +2681,14 @@ vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
         <para>Finally, on SUSE Linux Enterprise Server 15 SP4 it is possible to select
           the <parameter>haltpoll</parameter> CPU-Idle governor, inside the VM, even if we are using <parameter>model='host-model'</parameter>
           (although, it would will be only partially effective, as it would require <parameter>model='host-passthourgh'</parameter>
-          in order for the VM to be able to exploit its full potential).
-          This is an optimization meant at reducing the number of context switches between the VM and the host
+          in order for the VM to be able to exploit its full potential). In order to enable that, it is enough to load the
+          kernel module (inside of the VM, of course): </para>
+
+        <screen>
+vm1:~ # modprobe cpuidle-haltpoll
+        </screen>
+
+        <para>This is an optimization meant at reducing the number of context switches between the VM and the host
           (also known as VMExits), when doing static resource partitioning of the host itself.
           For that reason, it is something that we recommend using. Beware, however, that the actual benefit it
           will provide highly depends on the workload running inside of the VM.</para>

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -3219,105 +3219,499 @@ dmesg | grep SEV
 
   </sect1>-->
 
-  <!-- Append A Virtualisation Specific
   <sect1 xml:id="sec-appendix-a">
     <title>Appendix A</title>
 
     <para>Example of a VM configuration file:</para>
 
     <screen>
-&lt;domain type="kvm">
-  &lt;name>vm1&lt;/name>
+&lt;domain type='kvm'>
+  &lt;name>1vm_vm1&lt;/name>
   &lt;metadata>
     &lt;libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
       &lt;libosinfo:os id="http://suse.com/sle/15.4"/>
     &lt;/libosinfo:libosinfo>
   &lt;/metadata>
-  &lt;memory unit="KiB">704643072&lt;/memory>
-  &lt;currentMemory unit="KiB">704643072&lt;/currentMemory>
+  &lt;memory unit='KiB'>704643072&lt;/memory>
+  &lt;currentMemory unit='KiB'>704643072&lt;/currentMemory>
   &lt;memoryBacking>
     &lt;hugepages>
-      &lt;page size="1048576" unit="KiB"/>
+      &lt;page size='1048576' unit='KiB'/>
     &lt;/hugepages>
     &lt;nosharepages/>
+    &lt;locked/>
   &lt;/memoryBacking>
-  &lt;vcpu placement="static">288&lt;/vcpu>
+  &lt;vcpu placement='static'>288&lt;/vcpu>
   &lt;cputune>
-TODO
+    &lt;vcpupin vcpu='0' cpuset='0'/>
+    &lt;vcpupin vcpu='1' cpuset='192'/>
+    &lt;vcpupin vcpu='2' cpuset='1'/>
+    &lt;vcpupin vcpu='3' cpuset='193'/>
+    &lt;vcpupin vcpu='4' cpuset='2'/>
+    &lt;vcpupin vcpu='5' cpuset='194'/>
+    &lt;vcpupin vcpu='6' cpuset='3'/>
+    &lt;vcpupin vcpu='7' cpuset='195'/>
+    &lt;vcpupin vcpu='8' cpuset='4'/>
+    &lt;vcpupin vcpu='9' cpuset='196'/>
+    &lt;vcpupin vcpu='10' cpuset='5'/>
+    &lt;vcpupin vcpu='11' cpuset='197'/>
+    &lt;vcpupin vcpu='12' cpuset='6'/>
+    &lt;vcpupin vcpu='13' cpuset='198'/>
+    &lt;vcpupin vcpu='14' cpuset='7'/>
+    &lt;vcpupin vcpu='15' cpuset='199'/>
+    &lt;vcpupin vcpu='16' cpuset='8'/>
+    &lt;vcpupin vcpu='17' cpuset='200'/>
+    &lt;vcpupin vcpu='18' cpuset='9'/>
+    &lt;vcpupin vcpu='19' cpuset='201'/>
+    &lt;vcpupin vcpu='20' cpuset='10'/>
+    &lt;vcpupin vcpu='21' cpuset='202'/>
+    &lt;vcpupin vcpu='22' cpuset='11'/>
+    &lt;vcpupin vcpu='23' cpuset='203'/>
+    &lt;vcpupin vcpu='24' cpuset='12'/>
+    &lt;vcpupin vcpu='25' cpuset='204'/>
+    &lt;vcpupin vcpu='26' cpuset='13'/>
+    &lt;vcpupin vcpu='27' cpuset='205'/>
+    &lt;vcpupin vcpu='28' cpuset='14'/>
+    &lt;vcpupin vcpu='29' cpuset='206'/>
+    &lt;vcpupin vcpu='30' cpuset='15'/>
+    &lt;vcpupin vcpu='31' cpuset='207'/>
+    &lt;vcpupin vcpu='32' cpuset='16'/>
+    &lt;vcpupin vcpu='33' cpuset='208'/>
+    &lt;vcpupin vcpu='34' cpuset='17'/>
+    &lt;vcpupin vcpu='35' cpuset='209'/>
+    &lt;vcpupin vcpu='36' cpuset='18'/>
+    &lt;vcpupin vcpu='37' cpuset='210'/>
+    &lt;vcpupin vcpu='38' cpuset='19'/>
+    &lt;vcpupin vcpu='39' cpuset='211'/>
+    &lt;vcpupin vcpu='40' cpuset='20'/>
+    &lt;vcpupin vcpu='41' cpuset='212'/>
+    &lt;vcpupin vcpu='42' cpuset='21'/>
+    &lt;vcpupin vcpu='43' cpuset='213'/>
+    &lt;vcpupin vcpu='44' cpuset='22'/>
+    &lt;vcpupin vcpu='45' cpuset='214'/>
+    &lt;vcpupin vcpu='46' cpuset='23'/>
+    &lt;vcpupin vcpu='47' cpuset='215'/>
+    &lt;vcpupin vcpu='48' cpuset='24'/>
+    &lt;vcpupin vcpu='49' cpuset='216'/>
+    &lt;vcpupin vcpu='50' cpuset='25'/>
+    &lt;vcpupin vcpu='51' cpuset='217'/>
+    &lt;vcpupin vcpu='52' cpuset='26'/>
+    &lt;vcpupin vcpu='53' cpuset='218'/>
+    &lt;vcpupin vcpu='54' cpuset='27'/>
+    &lt;vcpupin vcpu='55' cpuset='219'/>
+    &lt;vcpupin vcpu='56' cpuset='28'/>
+    &lt;vcpupin vcpu='57' cpuset='220'/>
+    &lt;vcpupin vcpu='58' cpuset='29'/>
+    &lt;vcpupin vcpu='59' cpuset='221'/>
+    &lt;vcpupin vcpu='60' cpuset='30'/>
+    &lt;vcpupin vcpu='61' cpuset='222'/>
+    &lt;vcpupin vcpu='62' cpuset='31'/>
+    &lt;vcpupin vcpu='63' cpuset='223'/>
+    &lt;vcpupin vcpu='64' cpuset='32'/>
+    &lt;vcpupin vcpu='65' cpuset='224'/>
+    &lt;vcpupin vcpu='66' cpuset='33'/>
+    &lt;vcpupin vcpu='67' cpuset='225'/>
+    &lt;vcpupin vcpu='68' cpuset='34'/>
+    &lt;vcpupin vcpu='69' cpuset='226'/>
+    &lt;vcpupin vcpu='70' cpuset='35'/>
+    &lt;vcpupin vcpu='71' cpuset='227'/>
+    &lt;vcpupin vcpu='72' cpuset='36'/>
+    &lt;vcpupin vcpu='73' cpuset='228'/>
+    &lt;vcpupin vcpu='74' cpuset='37'/>
+    &lt;vcpupin vcpu='75' cpuset='229'/>
+    &lt;vcpupin vcpu='76' cpuset='38'/>
+    &lt;vcpupin vcpu='77' cpuset='230'/>
+    &lt;vcpupin vcpu='78' cpuset='39'/>
+    &lt;vcpupin vcpu='79' cpuset='231'/>
+    &lt;vcpupin vcpu='80' cpuset='40'/>
+    &lt;vcpupin vcpu='81' cpuset='232'/>
+    &lt;vcpupin vcpu='82' cpuset='41'/>
+    &lt;vcpupin vcpu='83' cpuset='233'/>
+    &lt;vcpupin vcpu='84' cpuset='42'/>
+    &lt;vcpupin vcpu='85' cpuset='234'/>
+    &lt;vcpupin vcpu='86' cpuset='43'/>
+    &lt;vcpupin vcpu='87' cpuset='235'/>
+    &lt;vcpupin vcpu='88' cpuset='44'/>
+    &lt;vcpupin vcpu='89' cpuset='236'/>
+    &lt;vcpupin vcpu='90' cpuset='45'/>
+    &lt;vcpupin vcpu='91' cpuset='237'/>
+    &lt;vcpupin vcpu='92' cpuset='46'/>
+    &lt;vcpupin vcpu='93' cpuset='238'/>
+    &lt;vcpupin vcpu='94' cpuset='47'/>
+    &lt;vcpupin vcpu='95' cpuset='239'/>
+    &lt;vcpupin vcpu='96' cpuset='48'/>
+    &lt;vcpupin vcpu='97' cpuset='240'/>
+    &lt;vcpupin vcpu='98' cpuset='49'/>
+    &lt;vcpupin vcpu='99' cpuset='241'/>
+    &lt;vcpupin vcpu='100' cpuset='50'/>
+    &lt;vcpupin vcpu='101' cpuset='242'/>
+    &lt;vcpupin vcpu='102' cpuset='51'/>
+    &lt;vcpupin vcpu='103' cpuset='243'/>
+    &lt;vcpupin vcpu='104' cpuset='52'/>
+    &lt;vcpupin vcpu='105' cpuset='244'/>
+    &lt;vcpupin vcpu='106' cpuset='53'/>
+    &lt;vcpupin vcpu='107' cpuset='245'/>
+    &lt;vcpupin vcpu='108' cpuset='54'/>
+    &lt;vcpupin vcpu='109' cpuset='246'/>
+    &lt;vcpupin vcpu='110' cpuset='55'/>
+    &lt;vcpupin vcpu='111' cpuset='247'/>
+    &lt;vcpupin vcpu='112' cpuset='56'/>
+    &lt;vcpupin vcpu='113' cpuset='248'/>
+    &lt;vcpupin vcpu='114' cpuset='57'/>
+    &lt;vcpupin vcpu='115' cpuset='249'/>
+    &lt;vcpupin vcpu='116' cpuset='58'/>
+    &lt;vcpupin vcpu='117' cpuset='250'/>
+    &lt;vcpupin vcpu='118' cpuset='59'/>
+    &lt;vcpupin vcpu='119' cpuset='251'/>
+    &lt;vcpupin vcpu='120' cpuset='60'/>
+    &lt;vcpupin vcpu='121' cpuset='252'/>
+    &lt;vcpupin vcpu='122' cpuset='61'/>
+    &lt;vcpupin vcpu='123' cpuset='253'/>
+    &lt;vcpupin vcpu='124' cpuset='62'/>
+    &lt;vcpupin vcpu='125' cpuset='254'/>
+    &lt;vcpupin vcpu='126' cpuset='63'/>
+    &lt;vcpupin vcpu='127' cpuset='255'/>
+    &lt;vcpupin vcpu='128' cpuset='64'/>
+    &lt;vcpupin vcpu='129' cpuset='256'/>
+    &lt;vcpupin vcpu='130' cpuset='65'/>
+    &lt;vcpupin vcpu='131' cpuset='257'/>
+    &lt;vcpupin vcpu='132' cpuset='66'/>
+    &lt;vcpupin vcpu='133' cpuset='258'/>
+    &lt;vcpupin vcpu='134' cpuset='67'/>
+    &lt;vcpupin vcpu='135' cpuset='259'/>
+    &lt;vcpupin vcpu='136' cpuset='68'/>
+    &lt;vcpupin vcpu='137' cpuset='260'/>
+    &lt;vcpupin vcpu='138' cpuset='69'/>
+    &lt;vcpupin vcpu='139' cpuset='261'/>
+    &lt;vcpupin vcpu='140' cpuset='70'/>
+    &lt;vcpupin vcpu='141' cpuset='262'/>
+    &lt;vcpupin vcpu='142' cpuset='71'/>
+    &lt;vcpupin vcpu='143' cpuset='263'/>
+    &lt;vcpupin vcpu='144' cpuset='96'/>
+    &lt;vcpupin vcpu='145' cpuset='288'/>
+    &lt;vcpupin vcpu='146' cpuset='97'/>
+    &lt;vcpupin vcpu='147' cpuset='289'/>
+    &lt;vcpupin vcpu='148' cpuset='98'/>
+    &lt;vcpupin vcpu='149' cpuset='290'/>
+    &lt;vcpupin vcpu='150' cpuset='99'/>
+    &lt;vcpupin vcpu='151' cpuset='291'/>
+    &lt;vcpupin vcpu='152' cpuset='100'/>
+    &lt;vcpupin vcpu='153' cpuset='292'/>
+    &lt;vcpupin vcpu='154' cpuset='101'/>
+    &lt;vcpupin vcpu='155' cpuset='293'/>
+    &lt;vcpupin vcpu='156' cpuset='102'/>
+    &lt;vcpupin vcpu='157' cpuset='294'/>
+    &lt;vcpupin vcpu='158' cpuset='103'/>
+    &lt;vcpupin vcpu='159' cpuset='295'/>
+    &lt;vcpupin vcpu='160' cpuset='104'/>
+    &lt;vcpupin vcpu='161' cpuset='296'/>
+    &lt;vcpupin vcpu='162' cpuset='105'/>
+    &lt;vcpupin vcpu='163' cpuset='297'/>
+    &lt;vcpupin vcpu='164' cpuset='106'/>
+    &lt;vcpupin vcpu='165' cpuset='298'/>
+    &lt;vcpupin vcpu='166' cpuset='107'/>
+    &lt;vcpupin vcpu='167' cpuset='299'/>
+    &lt;vcpupin vcpu='168' cpuset='108'/>
+    &lt;vcpupin vcpu='169' cpuset='300'/>
+    &lt;vcpupin vcpu='170' cpuset='109'/>
+    &lt;vcpupin vcpu='171' cpuset='301'/>
+    &lt;vcpupin vcpu='172' cpuset='110'/>
+    &lt;vcpupin vcpu='173' cpuset='302'/>
+    &lt;vcpupin vcpu='174' cpuset='111'/>
+    &lt;vcpupin vcpu='175' cpuset='303'/>
+    &lt;vcpupin vcpu='176' cpuset='112'/>
+    &lt;vcpupin vcpu='177' cpuset='304'/>
+    &lt;vcpupin vcpu='178' cpuset='113'/>
+    &lt;vcpupin vcpu='179' cpuset='305'/>
+    &lt;vcpupin vcpu='180' cpuset='114'/>
+    &lt;vcpupin vcpu='181' cpuset='306'/>
+    &lt;vcpupin vcpu='182' cpuset='115'/>
+    &lt;vcpupin vcpu='183' cpuset='307'/>
+    &lt;vcpupin vcpu='184' cpuset='116'/>
+    &lt;vcpupin vcpu='185' cpuset='308'/>
+    &lt;vcpupin vcpu='186' cpuset='117'/>
+    &lt;vcpupin vcpu='187' cpuset='309'/>
+    &lt;vcpupin vcpu='188' cpuset='118'/>
+    &lt;vcpupin vcpu='189' cpuset='310'/>
+    &lt;vcpupin vcpu='190' cpuset='119'/>
+    &lt;vcpupin vcpu='191' cpuset='311'/>
+    &lt;vcpupin vcpu='192' cpuset='120'/>
+    &lt;vcpupin vcpu='193' cpuset='312'/>
+    &lt;vcpupin vcpu='194' cpuset='121'/>
+    &lt;vcpupin vcpu='195' cpuset='313'/>
+    &lt;vcpupin vcpu='196' cpuset='122'/>
+    &lt;vcpupin vcpu='197' cpuset='314'/>
+    &lt;vcpupin vcpu='198' cpuset='123'/>
+    &lt;vcpupin vcpu='199' cpuset='315'/>
+    &lt;vcpupin vcpu='200' cpuset='124'/>
+    &lt;vcpupin vcpu='201' cpuset='316'/>
+    &lt;vcpupin vcpu='202' cpuset='125'/>
+    &lt;vcpupin vcpu='203' cpuset='317'/>
+    &lt;vcpupin vcpu='204' cpuset='126'/>
+    &lt;vcpupin vcpu='205' cpuset='318'/>
+    &lt;vcpupin vcpu='206' cpuset='127'/>
+    &lt;vcpupin vcpu='207' cpuset='319'/>
+    &lt;vcpupin vcpu='208' cpuset='128'/>
+    &lt;vcpupin vcpu='209' cpuset='320'/>
+    &lt;vcpupin vcpu='210' cpuset='129'/>
+    &lt;vcpupin vcpu='211' cpuset='321'/>
+    &lt;vcpupin vcpu='212' cpuset='130'/>
+    &lt;vcpupin vcpu='213' cpuset='322'/>
+    &lt;vcpupin vcpu='214' cpuset='131'/>
+    &lt;vcpupin vcpu='215' cpuset='323'/>
+    &lt;vcpupin vcpu='216' cpuset='132'/>
+    &lt;vcpupin vcpu='217' cpuset='324'/>
+    &lt;vcpupin vcpu='218' cpuset='133'/>
+    &lt;vcpupin vcpu='219' cpuset='325'/>
+    &lt;vcpupin vcpu='220' cpuset='134'/>
+    &lt;vcpupin vcpu='221' cpuset='326'/>
+    &lt;vcpupin vcpu='222' cpuset='135'/>
+    &lt;vcpupin vcpu='223' cpuset='327'/>
+    &lt;vcpupin vcpu='224' cpuset='136'/>
+    &lt;vcpupin vcpu='225' cpuset='328'/>
+    &lt;vcpupin vcpu='226' cpuset='137'/>
+    &lt;vcpupin vcpu='227' cpuset='329'/>
+    &lt;vcpupin vcpu='228' cpuset='138'/>
+    &lt;vcpupin vcpu='229' cpuset='330'/>
+    &lt;vcpupin vcpu='230' cpuset='139'/>
+    &lt;vcpupin vcpu='231' cpuset='331'/>
+    &lt;vcpupin vcpu='232' cpuset='140'/>
+    &lt;vcpupin vcpu='233' cpuset='332'/>
+    &lt;vcpupin vcpu='234' cpuset='141'/>
+    &lt;vcpupin vcpu='235' cpuset='333'/>
+    &lt;vcpupin vcpu='236' cpuset='142'/>
+    &lt;vcpupin vcpu='237' cpuset='334'/>
+    &lt;vcpupin vcpu='238' cpuset='143'/>
+    &lt;vcpupin vcpu='239' cpuset='335'/>
+    &lt;vcpupin vcpu='240' cpuset='144'/>
+    &lt;vcpupin vcpu='241' cpuset='336'/>
+    &lt;vcpupin vcpu='242' cpuset='145'/>
+    &lt;vcpupin vcpu='243' cpuset='337'/>
+    &lt;vcpupin vcpu='244' cpuset='146'/>
+    &lt;vcpupin vcpu='245' cpuset='338'/>
+    &lt;vcpupin vcpu='246' cpuset='147'/>
+    &lt;vcpupin vcpu='247' cpuset='339'/>
+    &lt;vcpupin vcpu='248' cpuset='148'/>
+    &lt;vcpupin vcpu='249' cpuset='340'/>
+    &lt;vcpupin vcpu='250' cpuset='149'/>
+    &lt;vcpupin vcpu='251' cpuset='341'/>
+    &lt;vcpupin vcpu='252' cpuset='150'/>
+    &lt;vcpupin vcpu='253' cpuset='342'/>
+    &lt;vcpupin vcpu='254' cpuset='151'/>
+    &lt;vcpupin vcpu='255' cpuset='343'/>
+    &lt;vcpupin vcpu='256' cpuset='152'/>
+    &lt;vcpupin vcpu='257' cpuset='344'/>
+    &lt;vcpupin vcpu='258' cpuset='153'/>
+    &lt;vcpupin vcpu='259' cpuset='345'/>
+    &lt;vcpupin vcpu='260' cpuset='154'/>
+    &lt;vcpupin vcpu='261' cpuset='346'/>
+    &lt;vcpupin vcpu='262' cpuset='155'/>
+    &lt;vcpupin vcpu='263' cpuset='347'/>
+    &lt;vcpupin vcpu='264' cpuset='156'/>
+    &lt;vcpupin vcpu='265' cpuset='348'/>
+    &lt;vcpupin vcpu='266' cpuset='157'/>
+    &lt;vcpupin vcpu='267' cpuset='349'/>
+    &lt;vcpupin vcpu='268' cpuset='158'/>
+    &lt;vcpupin vcpu='269' cpuset='350'/>
+    &lt;vcpupin vcpu='270' cpuset='159'/>
+    &lt;vcpupin vcpu='271' cpuset='351'/>
+    &lt;vcpupin vcpu='272' cpuset='160'/>
+    &lt;vcpupin vcpu='273' cpuset='352'/>
+    &lt;vcpupin vcpu='274' cpuset='161'/>
+    &lt;vcpupin vcpu='275' cpuset='353'/>
+    &lt;vcpupin vcpu='276' cpuset='162'/>
+    &lt;vcpupin vcpu='277' cpuset='354'/>
+    &lt;vcpupin vcpu='278' cpuset='163'/>
+    &lt;vcpupin vcpu='279' cpuset='355'/>
+    &lt;vcpupin vcpu='280' cpuset='164'/>
+    &lt;vcpupin vcpu='281' cpuset='356'/>
+    &lt;vcpupin vcpu='282' cpuset='165'/>
+    &lt;vcpupin vcpu='283' cpuset='357'/>
+    &lt;vcpupin vcpu='284' cpuset='166'/>
+    &lt;vcpupin vcpu='285' cpuset='358'/>
+    &lt;vcpupin vcpu='286' cpuset='167'/>
+    &lt;vcpupin vcpu='287' cpuset='359'/>
   &lt;/cputune>
   &lt;numatune>
-    &lt;memory mode="strict" nodeset="0-1"/>
-    &lt;memnode cellid="0" mode="strict" nodeset="0"/>
-    &lt;memnode cellid="1" mode="strict" nodeset="1"/>
+    &lt;memory mode='strict' nodeset='0-1'/>
+    &lt;memnode cellid='0' mode='strict' nodeset='0'/>
+    &lt;memnode cellid='1' mode='strict' nodeset='1'/>
   &lt;/numatune>
-  &lt;os firmware="efi">
-    &lt;type arch="x86_64" machine="pc-q35-6.2">hvm&lt;/type>
-    &lt;boot dev="hd"/>
+  &lt;os firmware='efi'>
+    &lt;type arch='x86_64' machine='pc-q35-6.2'>hvm&lt;/type>
+    &lt;boot dev='hd'/>
   &lt;/os>
   &lt;features>
     &lt;acpi/>
     &lt;apic/>
-    &lt;vmport state="off"/>
-    &lt;ioapic driver="qemu"/>
+    &lt;vmport state='off'/>
+    &lt;ioapic driver='qemu'/>
+    &lt;kvm>
+      &lt;hint-dedicated state="on"/>
+    &lt;/kvm>
   &lt;/features>
-  &lt;cpu mode="host-model" check="none">
-    &lt;topology sockets="2" dies="9" cores="8" threads="2"/>
+  &lt;cpu mode='host-model' check='none'>
+    &lt;topology sockets='2' dies='9' cores='8' threads='2'/>
     &lt;numa>
-      &lt;cell id="0" cpus="0-143" memory="352321536" unit="KiB">
+      &lt;cell id='0' cpus='0-143' memory='352321536' unit='KiB'>
         &lt;distances>
-          &lt;sibling id="0" value="10"/>
-          &lt;sibling id="1" value="32"/>
+          &lt;sibling id='0' value='10'/>
+          &lt;sibling id='1' value='32'/>
         &lt;/distances>
       &lt;/cell>
-      &lt;cell id="1" cpus="144-287" memory="352321536" unit="KiB">
+      &lt;cell id='1' cpus='144-287' memory='352321536' unit='KiB'>
         &lt;distances>
-          &lt;sibling id="0" value="32"/>
-          &lt;sibling id="1" value="10"/>
+          &lt;sibling id='0' value='32'/>
+          &lt;sibling id='1' value='10'/>
         &lt;/distances>
       &lt;/cell>
     &lt;/numa>
   &lt;/cpu>
-  &lt;clock offset="utc">
-    &lt;timer name="rtc" tickpolicy="catchup"/>
-    &lt;timer name="pit" tickpolicy="delay"/>
-    &lt;timer name="hpet" present="no"/>
+  &lt;clock offset='utc'>
+    &lt;timer name='rtc' tickpolicy='catchup'/>
+    &lt;timer name='pit' tickpolicy='delay'/>
+    &lt;timer name='hpet' present='no'/>
   &lt;/clock>
   &lt;on_poweroff>destroy&lt;/on_poweroff>
   &lt;on_reboot>restart&lt;/on_reboot>
   &lt;on_crash>destroy&lt;/on_crash>
   &lt;pm>
-    &lt;suspend-to-mem enabled="no"/>
-    &lt;suspend-to-disk enabled="no"/>
+    &lt;suspend-to-mem enabled='no'/>
+    &lt;suspend-to-disk enabled='no'/>
   &lt;/pm>
   &lt;devices>
     &lt;emulator>/usr/bin/qemu-system-x86_64&lt;/emulator>
-    &lt;disk type="file" device="disk">
-      &lt;driver name="qemu" type="qcow2" discard="unmap"/>
-      &lt;source file="/var/lib/libvirt/images/vm1.qcow2"/>
-      &lt;target dev="vda" bus="virtio"/>
+    &lt;disk type='file' device='disk'>
+      &lt;driver name='qemu' type='qcow2' discard='unmap'/>
+      &lt;source file='/abuild/vm1.qcow2'/>
+      &lt;target dev='vda' bus='virtio'/>
+      &lt;address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
     &lt;/disk>
-    ...
-    &lt;interface type="network">
-      &lt;mac address="52:54:00:16:1e:01"/>
-      &lt;source network="default"/>
-      &lt;model type="virtio"/>
+    &lt;controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      &lt;address type='pci' domain='0x0000' bus='0x02' slot='0x00' function='0x0'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='0' model='pcie-root'/>
+    &lt;controller type='pci' index='1' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='1' port='0x10'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0' multifunction='on'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='2' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='2' port='0x11'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x1'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='3' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='3' port='0x12'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x2'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='4' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='4' port='0x13'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x3'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='5' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='5' port='0x14'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x4'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='6' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='6' port='0x15'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x5'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='7' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='7' port='0x16'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x6'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='8' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='8' port='0x17'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x7'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='9' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='9' port='0x18'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0' multifunction='on'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='10' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='10' port='0x19'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x1'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='11' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='11' port='0x1a'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x2'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='12' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='12' port='0x1b'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x3'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='13' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='13' port='0x1c'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x4'/>
+    &lt;/controller>
+    &lt;controller type='pci' index='14' model='pcie-root-port'>
+      &lt;model name='pcie-root-port'/>
+      &lt;target chassis='14' port='0x1d'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x5'/>
+    &lt;/controller>
+    &lt;controller type='sata' index='0'>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>
+    &lt;/controller>
+    &lt;controller type='virtio-serial' index='0'>
+      &lt;address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
+    &lt;/controller>
+    &lt;interface type='network'>
+      &lt;source network='default'/>
+      &lt;model type='virtio'/>
+      &lt;address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
     &lt;/interface>
-    ...
-    &lt;rng model="virtio">
-      &lt;backend model="random">/dev/urandom&lt;/backend>
+    &lt;serial type='pty'>
+      &lt;target type='isa-serial' port='0'>
+        &lt;model name='isa-serial'/>
+      &lt;/target>
+    &lt;/serial>
+    &lt;console type='pty'>
+      &lt;target type='serial' port='0'/>
+    &lt;/console>
+    &lt;channel type='unix'>
+      &lt;target type='virtio' name='org.qemu.guest_agent.0'/>
+      &lt;address type='virtio-serial' controller='0' bus='0' port='1'/>
+    &lt;/channel>
+    &lt;input type='tablet' bus='usb'>
+      &lt;address type='usb' bus='0' port='1'/>
+    &lt;/input>
+    &lt;input type='mouse' bus='ps2'/>
+    &lt;input type='keyboard' bus='ps2'/>
+    &lt;graphics type='vnc' port='-1' autoport='yes'>
+      &lt;listen type='address'/>
+    &lt;/graphics>
+    &lt;audio id='1' type='none'/>
+    &lt;video>
+      &lt;model type='virtio' heads='1' primary='yes'/>
+      &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+    &lt;/video>
+    &lt;memballoon model='virtio'>
+      &lt;address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
+    &lt;/memballoon>
+    &lt;rng model='virtio'>
+      &lt;backend model='random'>/dev/urandom&lt;/backend>
+      &lt;address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
     &lt;/rng>
-    &lt;tpm model="tpm-crb">
-      &lt;backend type="emulator" version="2.0"/>
-    &lt;/tpm>
-    &lt;iommu model="intel">
-      &lt;driver intremap="on" eim="on"/>
+    &lt;iommu model='intel'>
+      &lt;driver intremap='on' eim='on'/>
     &lt;/iommu>
   &lt;/devices>
 &lt;/domain>
     </screen>
 
   </sect1>
--->
 
   <?pdfpagebreak style="sbp" formatter="fop"?>
 

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -1863,7 +1863,7 @@ epyc:~ # perf script
       <sect3 xml:id="sec-allocating-resources-hostos-kvm">
         <title>Reserving CPUs and memory for the host on KVM</title>
 
-        <para> When using KVM, sparing, for example, 12 cores (i.e., one full core for each CCX) and 64 GB of RAM for the host OS is
+        <para> When using KVM, sparing, for example, 24 cores (i.e., one full core for each CCX on both NUMA nodes) and 64 GB of RAM for the host OS is
           done by stopping creating VMs when the total number of vCPUs of all VMs has reached 336
           (as each core has 2 threads) or when the total cumulative amount of allocated RAM has
           reached 690 GB. </para>
@@ -1883,9 +1883,9 @@ epyc:~ # perf script
           the following additional parameters on the hypervisor boot command line (for example, by
           editing <filename>/etc/defaults/grub</filename>, and then updating the boot loader): </para>
 
-        <screen>dom0_mem=65536M,max:65536M dom0_max_vcpus=24</screen>
+        <screen>dom0_mem=65536M,max:65536M dom0_max_vcpus=48</screen>
 
-        <para> The number of vCPUs is 24 because we want Dom0 to have 12 physical cores, and the AMD
+        <para> The number of vCPUs is 24 because we want Dom0 to have 24 physical cores, and the AMD
           EPYC 9004 Series Processor has Symmetric multithreading (SMT). 65536M memory (that is 64
           GB) is specified both as current and as maximum value, to prevent Dom0 from using
           ballooning (see <link
@@ -2050,16 +2050,14 @@ epyc:~ # perf script
           xlink:href="https://libvirt.org/kbase/launch_security_sev.html#Host"> Libvirt
           documentation: Enabling SEV on the host</link>. </para>
 
-<!-- DOUBLE CHECK THE NUMBERS FROM THE EXPERIMENTS
       <para> It should be noted that, at least as far as the workload analyzed in this document,
         enabling SEV-ES on the host has not caused any noticeable performance degradation. In fact,
         running CPU and memory intensive workloads, both on the host and in VMs, with or without the
         parameters above added to the host kernel boot command line, resulted in indistinguishable
-        results. Therefore, enabling SEV at the host level can be considered safe, from the point of
-        view of not hurting performance of VMs and workloads that will not enable VM memory
-        encryption. Of course, this applies to when SEV is enabled for the host and is
+        results. Therefore, enabling SEV-ES at the host level can be considered safe, from the point of
+        view of not hurting performance of VMs and workloads that will not take advantage of VM memory
+        encryption. Of course, this applies to when SEV-ES is enabled for the host and is
           <emphasis>not</emphasis> used for encrypting VMs. </para>
--->
 
       <para>What happens when SEV-ES is used for encrypting VMs' memory will be described later in the
         guide.</para>
@@ -2134,9 +2132,50 @@ epyc:~ # perf script
         only from the specified (set of) NUMA node(s) specified in <parameter>nodeset</parameter>. A
         cell is, in fact, a virtual NUMA node, with <parameter>cellid</parameter> being its ID and
           <parameter>nodeset</parameter> telling exactly from what host physical NUMA node(s) the
-        memory for this virtual node should be allocated. A NUMA-unaware VMs can still include this
+        memory for this virtual node should be allocated.</para>
+
+      <para>The correctness of this kind of tuning can be verified checking on which NUMA node(s)
+        the memory of the QEMU processes representing the VMs have been allocated on, by using the
+        <parameter>numastat</parameter> tool (on the host) like this:</para>
+
+      <screen>
+host:~ # numastat -p qemu-system-x86_64
+Per-node process memory usage (in MBs) for PID 53153 (qemu-system-x86)
+                           Node 0          Node 1           Total
+                  --------------- --------------- ---------------
+Huge                    344064.00       344064.00       688128.00
+Heap                         0.00          150.57          150.57
+Stack                        0.00            0.13            0.13
+Private                    149.59         4522.84         4672.43
+----------------  --------------- --------------- ---------------
+Total                   344213.59       348737.54       692951.12
+      </screen>
+
+      <para>In fact, we see that there is only 1 QEMU process (as there is only
+        1 VM running) and its memory footprint has been equally split between the
+        two NUMA nodes.</para>
+
+      <para>A NUMA-unaware VMs can still include this
         element in its configuration file. It will have only one
-          <parameter>&lt;memnode></parameter> element. </para>
+          <parameter>&lt;memnode></parameter> element, and the output of
+        <parameter>numastat</parameter> will look like this:</para>
+
+      <screen>
+deandre:/abuild/:[0]# numastat -p qemu-system-x86_64
+Per-node process memory usage (in MBs)
+PID                               Node 0          Node 1           Total
+-----------------------  --------------- --------------- ---------------
+184717 (qemu-system-x86)       346040.98           19.30       346060.28
+184980 (qemu-system-x86)           19.50       346227.04       346246.54
+-----------------------  --------------- --------------- ---------------
+Total                          346060.48       346246.34       692306.82
+      </screen>
+
+      <para>In this case there are 2 VMs running and their memory have been
+        pretty much entirely allocated on a single NUMA node: <parameter>Node 0</parameter>
+        for the VM associated to the QEMU process with PID <parameter>184717</parameter>,
+        and <parameter>Node 1</parameter> for the other one.
+      </para>
 
       <para>Placement of vCPUs happens via the <parameter>&lt;cputune></parameter> element, as
         in the example below:</para>
@@ -2277,14 +2316,15 @@ node   0
         <title>Placement of four to twentyfour medium-size VMs</title>
 
         <para> Following the same principles, we can <quote>split</quote> each node in 2, and have 4
-          VMs with 96 vCPUs and up to 168 GB of RAM each.
-          Or, maybe, have 12 VMs with 32 vCPUs and 56 GB RAM each.
-          And even 24 VMs, with 16 vCPUs and 28 GB RAM.</para>
+          VMs with 96 vCPUs and up to 168 GB of RAM each. It is also feasible to have 6 VMs with
+          64 vCPUs and up to 112 GB of RAM each, 12 VMs with 32 vCPUs and 56 GB RAM, or even
+          24 VMs, all with 16 vCPUs and 28 GB RAM.</para>
 
-        <para>In the first case, each VM will span 6 host dies. In the second, 2.
+        <para>In the first case, each VM will span 6 host dies. In the third and in the second,
+          to 4 and 2 dies.
           In the third one, each VM will be pinned to 1 die.</para>
 
-        <para> In both cases, VMs will not need to (and must not) be put across the host NUMA nodes
+        <para> In all these cases, VMs do not need to be placed across the host NUMA nodes
           boundary, and hence they do not need to be NUMA-aware. They still benefit from having a
           virtual topology, in terms of cores, threads and dies which matches the resource they are
           using. You will find more details about this in following sections. </para>
@@ -2306,7 +2346,9 @@ node   0
           This may or may not be a problem, but there is no way around it, as soon as more VMs than the number of available dies are necessary.
           The performance impact of such sharing should be tolerable, in most cases, for these configurations, but this needs to be assessed with tests and benchmarks.
           If that is not the case, then the recommendation is to not go above 24 VMs.
-          More clever (but also more complex) tuning strategies can be designed, but they would require further a-priori knowledge of, for instance, what is the workload and/or the load profile of the various VMs, which may not be available as an information.</para>
+          More clever (but also more complex) tuning strategies can be designed, but they would require further a-priori knowledge of
+          the workload and/or the load profile of the various VMs, which may not be always available (or can change during the lifecycle
+          of the VMs).</para>
 
         <note>
           <title>Hundreds of VMs with limited RAM size and disk sapce</title>
@@ -2384,10 +2426,9 @@ node   0
         impose on the system is always 100%, creating even 1 vCPUs more than the host has pCPUs
         can be considered a misconfiguration. </para>
 
-      <para> When under oversubscription, exclusive 1-to-1 vCPU to pCPU assignment may not the best
-        approach. However, we need to trust the hypervisor scheduler to handle the situation well
-        (which is very likely what will happen). What can be done, though, is to provide the
-        hypervisor scheduler with some <quote>suggestions</quote>, if we have enough knowledge about
+      <para> When oversubscription is necessary, exclusive 1-to-1 vCPU to pCPU assignment may not the best
+        approach and we need to trust the hypervisor scheduler to handle the situation well. What can be done, though, is providing such
+        scheduler at least with some <quote>suggestions</quote>, if we have enough knowledge about
         the workload. For example, we can try to help the scheduler avoiding that all the VMs
         running CPU intensive workloads end on the same nodes, or avoiding cross-node VM migrations
         happening too frequently. </para>
@@ -2518,9 +2559,6 @@ Caches (sum of all):
         <para>Both the CPU topology and the cache layout, as seen from inside of the VM, are completely wrong, and can affect performance of applications running inside the VM.
           In fact, not only the sizes of the various cache levels are wrong. It is also the information about which CPUs share what caches that is completely misconfigured, as shown also here: </para>
 
-        <para>Of course, now it is the <parameter>Model name:</parameter> that is not completely correct.
-          But both the CPU and caches layout is much more in line with what we wanted to achieve by tuning the VM configuration (remember that the VM has 288 vCPUs).</para>
-
         <screen>
 vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
 0
@@ -2565,12 +2603,14 @@ Caches (sum of all):
 ...
         </screen>
 
-        <para> Now it is the cache sizes that are slightly off, with regard to the host value. And
+        <para>Of course, now it is the <parameter>Model name:</parameter> that is not completely correct.
+          But both the CPU and caches layout is much more in line with what we wanted to achieve by tuning the VM configuration (remember that the VM has 288 vCPUs).</para>
+
+        <para>In fact, even if the cache sizes that are slightly off, with regard to the host value. And
           this is because they are the values taken from previous generation AMD EPYC Processors
           architecture characteristics. But the cache topology and cache level sharing among vCPUs
-          are now closer to the host ones (not perfectly, as <parameter>index3</parameter> should
-          report <parameter>0-15</parameter>). This is far more important for achieving performance
-          inside the VM that matches the one of the host. This is shown here: </para>
+          are now correct (as shown below). And this is far more important for achieving good performance
+          inside the VM. </para>
 
         <screen>
 vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
@@ -2583,20 +2623,11 @@ vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
 0-15
         </screen>
 
-        <para>Related to this, on SUSE Linux Enterprise Server 15 SP4 it would be possible to use
-          the <parameter>haltpoll</parameter> CPU-Idle governor, inside the VM. This is an
-          optimization meant at reducing the number of context switches between the VM and the host
-          (also known as VMExits), when doing static resource partitioning of the host itself.
-          For that reason, it would be something that we recommend using, the only problem being that it can be enabled only if the CPU model used is <parameter>host-passthrough</parameter>.</para>
-
-        <para>We therefore recommend to not use it in a SUSE Linux Enterprise Server 15 SP4 VM
-          running on an AMD EPYC 9004 Series Processors, until the inaccurate vCPU topology problem when using <parameter>host-passthrough</parameter> is resolved.</para>
-
         <para>Note that, in order to achieve the outcome shown above, it is very important to use the following CPU topology description string, in the VM configuration:</para>
 
         <screen>&lt;topology sockets="2" dies="9" cores="8" threads="2"/></screen>
 
-        <para>In particular, do not omit the <parameter>dies="9"</parameter> element, as that is what enables the VM to see its vCPUs grouped in dies, from the point of view of cache layer sharing.
+        <para>In particular, do not omit the <parameter>dies="9"</parameter> element, as that is what enables the VM to see its vCPUs grouped in dies.
           In fact, using something like this <parameter>&lt;topology sockets="2" cores="72" threads="2"/></parameter> would result in a correct CPU topology, but the representation of the cache layout would still be inaccurate, such as:</para>
 
         <screen>
@@ -2664,6 +2695,16 @@ vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
 vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
 0-15
         </screen>
+
+        <para>Finally, on SUSE Linux Enterprise Server 15 SP4 it is possible to select
+          the <parameter>haltpoll</parameter> CPU-Idle governor, inside the VM, even if we are using <parameter>model='host-model'</parameter>
+          (although, it would will be only partially effective, as it would require <parameter>model='host-passthourgh'</parameter>
+          in order for the VM to be able to exploit its full potential).
+          This is an optimization meant at reducing the number of context switches between the VM and the host
+          (also known as VMExits), when doing static resource partitioning of the host itself.
+          For that reason, it is something that we recommend using. Beware, however, that the actual benefit it
+          will provide highly depends on the workload running inside of the VM.</para>
+
       </sect3>
 
 
@@ -2673,7 +2714,7 @@ vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
         <para> Memory wise, the VMs need to be told to use the Huge Pages that were reserved for
           them. To effectively use 1 GB huge pages, the amount of memory each VM is given must be a
           multiple of 1 GB. Also, KSM should be disabled and we also must ensure that VMs' memory is
-          never going to be swapped out. This is all achieved as follows: </para>
+          never going to be swapped out. This is all achieved as follows:</para>
 
         <screen>
 &lt;memory unit='KiB'>704643072&lt;/memory>
@@ -2683,6 +2724,23 @@ vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
   &lt;/hugepages>
   &lt;nosharepages/>
 &lt;/memoryBacking>
+        </screen>
+
+        <para>In order to verify that the appropriate type of memory is being used by the VMs,
+          one can check the content of <parameter>/proc/meminfo</parameter>, with the VMs running,
+          and observe that all the pre-allocated Huge Pages are actually occupied.</para>
+
+        <screen>
+host:~ # cat /proc/meminfo | grep Huge
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+FileHugePages:         0 kB
+HugePages_Total:     672
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:    1048576 kB
+Hugetlb:        704643072 kB
         </screen>
 
         <note>
@@ -2778,10 +2836,16 @@ dmesg |grep SEV
       </screen>
 
       <para> Note that on SUSE Linux Enterprise Server 15 SP4, an SEV-enabled VM can use 1 GB Huge
-        Pages memory, preallocated at boot time, the same as when SEV is not enabled as they are
-        allocated during boot.</para>
+        Pages memory, preallocated at boot time..</para>
 
-      <para>Once inside of the VM, this is how one can check whether the memory and the state are being encrypted with SEV-ES:</para>
+      <para>Once inside of the VM, this is how one can check whether the memory and the state are being encrypted only with SEV:</para>
+
+      <screen>
+dmesg | grep SEV
+[    0.069436] AMD Memory Encryption Features active: SEV
+      </screen>
+
+      <para>Or if we are also fully encrypting the VM state with SEV-ES:</para>
 
       <screen>
 dmesg | grep SEV
@@ -2794,12 +2858,12 @@ dmesg | grep SEV
           <parameter>iommu</parameter> element, in the <parameter>&lt;device></parameter>
         section of the VM configuration. Since that element was necessary for having more than 255
         vCPUs in the VM, all the experiments conducted with SEV enabled have been done in VMs with
-        at most 224 vCPUs.</para>
+        at most 192 vCPUs.</para>
 
     </sect2>
 
   </sect1>
-<!--
+
   <sect1 xml:id="sec-virtualization-test-workload-stream">
     <title>Test VM workload: STREAM</title>
 
@@ -2810,49 +2874,71 @@ dmesg | grep SEV
       <title>Test scenario: One large VM</title>
 
       <para><xref linkend="fig-stream-bm-vm"/> shows the bandwidth achieved by STREAM when the
-        benchmark is built in single thread mode (single) or parallelized with OpenMP
-        (omp-llcs-spread). For both cases, we compare the results achieved on the host (BM) and
-        inside one VM (VM). </para>
+        benchmark is built in single thread mode ('single') or parallelized with OpenMP
+        ('ompenmp'). For both cases, we compare the results achieved on the host ('BM') and
+        inside one VM ('VM'). </para>
 
 
       <figure xml:id="fig-stream-bm-vm">
         <title>STREAM Bandwidth - Bare metal compared with one VM</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-bm-1vm.png" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-bm-1vm.png" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para> As the VM has approximately the same dimension and topology of the host, the same
-        STREAM configuration parameters used in <xref linkend="sec-workload-stream"/>, are used also
-        here. </para>
+      <para>The single thread results are basically identical between baremetal (blue rectangles) and inside of the VM (orange rectangles), for
+        all the operations (<parameter>Copy</parameter>, <parameter>Scale</parameter>, <parameter>Add</parameter> and
+        <parameter>Triadd</parameter>) of the benchmark.
+      </para>
 
-      <para> We can clearly see how proper tuning allows a VM running on an AMD EPYC 7003 Series
-        Processor server to achieve a memory bandwidth performance within 1% of the one of the host. </para>
+      <para> About the parallel case, remember that the VM is slightly "smaller"" than the host, in terms of number of CPUs. Therefore,
+        we cannot run the parallel version of STREAM with as many thread as on the host. In fact, a very good result is reached, on the host, with twice as many threads as there are
+        Least Level Caches (LLCs), i.e., 48. If we do the same inside of the VM, there it means 36 threads.
+        We can see, however, that the performance reached inside of the VM, even with 36 threads (dark red rectangles, ~616 GBytes/sec for the <parameter>Copy</parameter> operation)
+        is close enough to the values achieved on the host with 48 threads (yellow rectangles, ~640 GBytes/sec for the <parameter>Copy</parameter> operation).
+        For completeness, we also run the benchmark on the host with 36 threads (green rectangles, ~605 Gbytes/sec for the <parameter>Copy</parameter> operation); and as we
+        could have expectd, the results of such baremetal runs and of the VM runs are very close.</para>
 
-      <para><xref linkend="fig-stream-single-1vm-model"/> and <xref linkend="fig-stream-bm-vm"/>
-        show the effect of using different CPU models for the virtual machine. While with single
-        threaded STREAM it seems that CPU model is not a really important parameter, the OpenMP run
-        clearly show how the using the host-passthrough dramatically decreases the performance. </para>
+      <para> This clearly shows how proper tuning allows a single VM running on an AMD EPYC 7004 Series
+        Processor server to achieve a memory bandwidth performance that basically matches the one that we can reach directly on the host. </para>
 
-      <para>This seems counter-intuitive, as using host-passthrough and enabling the
-          <parameter>haltpoll</parameter> governor inside the guest is meant to provide the absolute
-        best performance when doing static host resource partitioning, as we are doing here.
-        However, we know that in our case this is because of the inaccurate cache hierarchy exposed
-        to the VM that this causes. </para>
+      <note>
+        <para>Inside of the VM, the STREAM benchmark was configured almost identically to what has been
+         shown already in <xref linkend="sec-workload-stream"/>. </para>
+      </note>
+
+      <para><xref linkend="fig-stream-single-1vm-model"/> and <xref linkend="fig-stream-omp-1vm-model"/>
+        show the effect of using different CPU models for the virtual machine. We see that, as long as
+        a single thread is used, the CPU model choosen for the VM is completely irrelevant.</para>
+
+      <para>On the other hand, the OpenMP run clearly shows some problems when the <parameter>host-passthrough</parameter> CPU model
+        is selected. In fact, since using that model builds a VM with only 2 LLCs (and also to other problems with the cache topology),
+        running STREAM with twice as many threads as there are LLCs in the system, results in the benchmark spawning only 4 of them (yellow and green rectangles).
+        And this, of course, dramatically reduces the performance. We can also see that, if we instead manually set the number of threads
+        to the value that we know to be the best for this VM (i.e., 36, dark red and cyan rectangles) performance are restored to how good
+        we know things can be from <xref linkend="fig-stream-bm-vm"/> (and from the <parameter>cpumodel</parameter> results, i.e. the blue and orange rectangles).</para>
+
+      <para>Actually, the cyan rectangles represent the absolute best result (~620 GBytes/sec for the <parameter>Copy</parameter> operation), probably thanks to the fact that the CPUIdle
+        <parameter>haltpoll</parameter> governor is the most effective when coupled with <parameter>cpupassthrough</parameter>. However, the orange rectangles follow very closely
+        (~614 Gbytes/sec for the <parameter>Copy</parameter> operation). And it is probably not worthwhile to tolerate a completely inaccurate cache hierarchy inside of the VM,
+        for such a small gain. In fact, sticking to <parameter>cpupassthrough</parameter> would likely mean having to manually tweak most applications, and this could be
+        much more complicated it has been here for the STREAM benchmark or, sometimes, even impossible. For this reason, this document recommends <parameter>cpumodel</parameter>
+        as the best compromise between convenience and absolute best performance.
+      </para>
 
       <figure xml:id="fig-stream-single-1vm-model">
         <title>STREAM Bandwidth - Single thread in one VM with different CPU models</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-single-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-1vm-model.png" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-single-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-1vm-model.png" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
@@ -2861,21 +2947,22 @@ dmesg | grep SEV
         <title>STREAM Bandwidth - OpenMP in one VM with different CPU models</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-omp-llcs-spread-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-omp-1vm-model.png" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-omp-llcs-spread-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-omp-1vm-model.png" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para>This confirms the need to always run benchmarks for assessing the performance of the
+      <para>This situation also confirms the need to always run benchmarks for assessing the performance of the
         relevant workloads, on a given platform. In fact, because of specific characteristics of
         some components of the virtualization stack available in SUSE Linux Enterprise Server 15
-        SP2, the <parameter>EPYC</parameter> CPU model (host-model) is preferable to what it would
-        have appeared to be the most obvious choice, which is the
-          <parameter>host-passthrough</parameter>. CPU model with <parameter>haltpoll</parameter>
-        governor enabled inside the guest.</para>
+        SP4, the <parameter>EPYC-Milan</parameter> (or, equivalently, the <parameter>host-model</parameter>) CPU model
+        might be preferable to what it would have appeared to be the most obvious choice (<parameter>host-passthrough</parameter>).</para>
+
+      <para>Finally, about the CPUIdle <parameter>haltpoll</parameter> governor, it is recommended to enable and make use of it,
+        although for STREAM (and we can guess also for other, similar, memory intensive benchmarks) it introduces no significant performance difference.</para>
 
     </sect2>
 
@@ -2883,84 +2970,117 @@ dmesg | grep SEV
       <title>Test scenario: Multiple VMs</title>
 
       <para>
-        <xref linkend="sec-virt-test-stream-sev"/> shows what happens when two or four large VMs are
-        used, both with the recommended tuning applied (performance of 1 VM is also displayed, for
-        reference). The graph reports the average memory bandwidth achieved in each experiments,
-        considering all the VMs involved. For example, the light blue bar (4 VMS) is relative to an
-        experiment where four VMs were used and represents the average of the four different memory
-        bandwidth values, one for each of the VMs. </para>
+        <xref linkend="fig-stream-single-vms-avg"/> and <xref linkend="fig-stream-single-vms-sum"/> show what happens when 1, 2, 4, 6, 12 or 24 VMs are used.
+        The former reports the average bandwidth achieved in each experiments, considering all the VMs involved. For example, the yellow blue bar (4 VMS) is relative to an
+        experiment where 4 VMs were concurrently running the STREAM benchmark (in single thread mode) and represents the average of the 4 different memory bandwidth values,
+        one for each of such VMs.
+        The latter shows something similar, but the bars represents the cumulative STREAM bandwidth achieved in each experiments, considering all the VMs involved.
+        For example, the cyan bar (24 VMs) is relative to an experiment where 24 VMs were concurrently running the STREAM benchmark (in single thread mode) and represents the sum
+        of the 24 different memory bandwidth values, one of each of such VMs.
+      </para>
 
-      <figure xml:id="fig-stream-omp-llcs-spread-vms-avgstd">
-        <title>STREAM Bandwidth - OpenMP, per-VM average when using multiple VMs</title>
+      <figure xml:id="fig-stream-single-vms-avg">
+        <title>STREAM Bandwidth - Single, average of the bandwidth achieved among all VMs of each group</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-omp-llcs-spread-vms-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-vms-avg.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-omp-llcs-spread-vms-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-vms-avg.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para>We can see that performance scales down in a close to linear fashion, with the increase
-        of the number of VMs involved (although, not perfectly linear for all the type of STREAM
-        operations). </para>
+      <figure xml:id="fig-stream-single-vms-sum">
+        <title>STREAM Bandwidth - Single, sum of the bandwidth achieved within all VMs of each group</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="EPYC4-stream-single-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="EPYC4-stream-single-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <para>We see in <xref linkend="fig-stream-single-vms-avg"/> how the single STREAM bandwidth stays basically flat until (and including when) 6 VMs are used.
+        Then it starts to decline a bit, as more VMs are packed on the NUMA nodes and, hence, compete for the bandwith of the memory controllers. However,
+         <xref linkend="fig-stream-single-vms-sum"/> reminds us how the total bandwidth achieved, if we consider all the VMs involved in each experiments, actually goes up,
+        until it reaches the same level that we know (e.g., from <xref linkend="fig-stream-bm-vm"/>) it can touch.
+      </para>
+
+      <para><xref linkend="fig-stream-omp-vms-avg"/> and <xref linkend="fig-stream-omp-vms-sum"/> show the same, but when the parallel (via OpenMP) version of STREAM
+        is run, inside of each VM of each experiment.</para>
+
+      <figure xml:id="fig-stream-omp-vms-avg">
+        <title>STREAM Bandwidth - OpenMP, average of the bandwidth achieved among all VMs of each group</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="EPYC4-stream-omp-vms-avg.svg" width="80%" format="PNG"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="EPYC4-stream-omp-vms-avg.svg" width="80%" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <figure xml:id="fig-stream-omp-vms-sum">
+        <title>STREAM Bandwidth - OpenMP, sum of the bandwidth achieved within all VMs of each group</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="EPYC4-stream-omp-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="EPYC4-stream-omp-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <para>In <xref linkend="fig-stream-omp-vms-avg"/> we see that performance scales down in a close to linear fashion with the increase
+        of the number of VMs involved (although, not perfectly linearly for all the type of STREAM operations).
+        At the same time, <xref linkend="fig-stream-omp-vms-sum"/> shows how the total cumulative bandwidth of each experiments stays high,
+        as one would expect. Actually, it even seems that using many small VMs may make it possible to even better exploit the large memory bandwidth
+        provided by the memory controllers of the EPYC 9004 processors, as compared to what happens when few large VMs are running.
+      </para>
 
     </sect2>
 
     <sect2 xml:id="sec-virt-test-stream-sev">
       <title>Test scenario: Secure Encrypted Virtualization</title>
 
-      <para>The goal for this test was evaluating the impact on the performance of SEV, on a memory
+      <para>The goal for this test was evaluating the impact on the performance of encrypting the VMs with SEV and with SEV-ES, when running a memory
         intensive workload like STREAM.</para>
 
-      <para> We can evaluate that looking at the results of running single threaded and parallelized
-        STREAM in one VM (in <xref linkend="fig-stream-1vms-sev-avg"/>), in two VMs (in <xref
-          linkend="fig-stream-2vms-sev-avg"/>) and in four VMs *in <xref
-          linkend="fig-stream-4vms-sev-avg"/>) running concurrently, both when SEV is disabled
-        (no-SEV) and when it is enabled (SEV). They again report the average of the bandwidth values
-        of each VM that was running in the particular experiment. </para>
+      <para>Considering the case when 2 VMs are concurrently running on the host and are executing the STREAM benchmark, <xref linkend="fig-stream-single-sev"/>
+        shows the average bandwidth of the single thread execution of the benchmark in both such VMs when memory is not encrypted (blue bars), when memory is
+        encrypted with SEV (orange bar) and with both memory and state are encrypted with SEV-ES (yellow bar).</para>
 
-      <figure xml:id="fig-stream-1vms-sev-avg">
-        <title>STREAM Bandwidth - Single and OpenMP, with and without SEV in 1 VM</title>
+      <figure xml:id="fig-stream-single-sev">
+        <title>STREAM Bandwidth - Single, average bandwidth in 2 VMs when unencrypted, encrypted with SEV and with SEV-ES</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-1vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-1vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <figure xml:id="fig-stream-2vms-sev-avg">
-        <title>STREAM Bandwidth - Single and OpenMP, with and without SEV in 2 VMs</title>
+      <figure xml:id="fig-stream-openmp-sev">
+        <title>STREAM Bandwidth - OpenMP, average bandwidth in 2 VMs when unencrypted, encrypted with SEV and with SEV-ES</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-2vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-openmp-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-2vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-openmp-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <figure xml:id="fig-stream-4vms-sev-avg">
-        <title>NAS Completion Time - Baremetal and in one VM, different configurations</title>
-        <mediaobject>
-          <imageobject role="fo">
-            <imagedata fileref="stream-4vms-sev-avg.png" width="80%" format="PNG"/>
-          </imageobject>
-          <imageobject role="html">
-            <imagedata fileref="stream-4vms-sev-avg.png" width="80%" format="PNG"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-
-      <para>It is quite evident that enabling SEV has only a very limited impact on the performance
-        for this workload, which is within 2% and 4% for most of the experiments. Even in the case
-        where the overhead is the highest (OpenMP Stream run inside 4 VMs), the performance decrease
-        is limited to around 6%.</para>
+      <para>It is quite evident how both SEV and SEV-ES are have only a very limited impact on the performance
+        for this workload. In fact, even when SEV-ES is employed, the drop in performance is limited to ~2%.</para>
 
     </sect2>
 
@@ -2969,92 +3089,88 @@ dmesg | grep SEV
   <sect1 xml:id="sec-virtualization-test-workload-npb">
     <title>Test VM workload: NPB</title>
 
-    <para>To match the experimental evaluation done on bare-metal, NPB base workloads have also been
+    <para>Trying to mach the experimental evaluation done on bare-metal, NPB base workloads have also been
       considered.</para>
 
     <sect2 xml:id="sec-virt-test-npb-onevm">
       <title>Test scenario: One large VM</title>
 
       <para><xref linkend="fig-nas-bm-1vm"/> shows the results of running the various NPB workloads
-        on the host in the default (BM default), tuned (BM tuned) and selective (BM selective)
-        configurations, compared with the exact same done inside one VM (VM default, VM tuned, VM
-        selective).</para>
+        on the host and in one VMs. In both cases, the tuning introduced above was applied (in the latter case, of course, inside of the VM itself).</para>
 
       <figure xml:id="fig-nas-bm-1vm">
-        <title>NAS Completion Time - Baremetal and in one VM with different configurations</title>
+        <title>NAS Completion Time - Baremetal and in one VM</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="nas-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-bm-1vm.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="nas-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-bm-1vm.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para> This makes pretty evident that, with proper tuning, also CPU bound workload running
-        inside a VM can achieve host-level performance. </para>
+      <para> The VM appears slightly solwer than the host, but this should have been
+        expected, considering that the VM can only have 288 CPUs. </para>
 
-      <para><xref linkend="fig-nas-selective-1vm-model"/> shows the impact of selecting a specific
-        CPU model for the VM (only the results for the selective configuration are reported). We see
-        that this aspect seems to play a smaller role for this benchmark, as compared to how it
-        changed the performance for STREAM. In any case, even for CPU bound workloads like NAS, the
-        EPYC model is the one to be preferred.</para>
+    </sect2>
 
-      <figure xml:id="fig-nas-selective-1vm-model">
-        <title>NAS Completion Time - Selective configuration in one VM, varying the CPU
-          model</title>
+    <sect2 xml:id="sec-virt-test-npb-multivm">
+      <title>Test scenario: Two to twelve VMs</title>
+
+      <para><xref linkend="fig-nas-bm-multivm"/> depicts the same as <xref linkend="fig-nas-bm-1vm"/>,
+        but for a few more cases, in terms of number of concurrently running VMs.
+      </para>
+
+      <figure xml:id="fig-nas-bm-multivm">
+        <title>NAS Completion Time - Baremetal and 2 to 12 VMs</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="nas-selective-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-bm-12vm.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="nas-selective-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-bm-12vm.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
+
+      <para> We can see how the slowdown is almost always linear with the number of the VMs, which
+        makes sense considering that when we increase the number of VMs, each one of them can also
+        have fewer CPUs (the only exceptions being <parameter>lu.D</parameter> and --but only to some extent
+        <parameter>sp.D</parameter>)-- especially with 12 VMs).
+        This testifies the effectivens of the suggested tuning measures, when it comes
+        to guerantee a good level of isolation of multiple concurrently running VMs, on the EPYC 9004 processors. </para>
 
     </sect2>
 
     <sect2 xml:id="sec-virt-test-npb-sev">
-      <title>Test scenario: Multiple VMs with Secure Encrypted Virtualization</title>
+      <title>Test scenario: Two VMs with Secure Encrypted Virtualization</title>
 
       <para>Similarly to what has been done with STREAM, we evaluate here the overhead introduced by
-        SEV for CPU on the NPB workloads and we do that while running it inside two (in <xref
-          linkend="fig-nas-tuned-2vms-sev"/>) and in four (<xref linkend="fig-nas-tuned-4vms-sev"/>)
-        VMs, with both SEV off and on.</para>
+        SEV and SEV-ES, this time for CPU-bound workloads, and we do that by running the NPB benchmarks it inside two VMs concurrently
+        that are all either unencrypted, encrypted with SEV or encrypted with SEV-ES (<xref linkend="fig-nas-tuned-2vms-sev"/>).</para>
 
       <figure xml:id="fig-nas-tuned-2vms-sev">
         <title>NAS Completion Time - Tuned configuration in 2 VM, with and without SEV</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="nas-tuned-2vms-sev.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-2vms-sev.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="nas-tuned-2vms-sev.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-2vms-sev.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <figure xml:id="fig-nas-tuned-4vms-sev">
-        <title>NAS Completion Time - Tuned configuration in 4 VM, with and without SEV</title>
-        <mediaobject>
-          <imageobject role="fo">
-            <imagedata fileref="nas-tuned-4vms-sev.png" width="80%" format="PNG"/>
-          </imageobject>
-          <imageobject role="html">
-            <imagedata fileref="nas-tuned-4vms-sev.png" width="80%" format="PNG"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-
-      <para>Results are again pretty good, as the performance penalty because of SEV, on a CPU intensive
-        benchmark like NPB, is nearly non-existent (it is less than 0.5%).</para>
+      <para>As for the memory-intensive case the overhead introduced by either of the Confidential Computing
+        technologies is found to be limited. In fact, the worst case is reached in the SEV-ES case
+        (as it could have be expected), during the <parameter>bt.D</parameter> benchmark, but is well
+        within 5% of the unencrypted run.
+      </para>
 
     </sect2>
 
   </sect1>
--->
 
   <sect1 xml:id="sec-resources">
     <title>Resources</title>

--- a/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-4-SLES15SP4.xml
@@ -1713,24 +1713,6 @@ epyc:~ # perf script
 
   </sect1>
 
-  <sect1 xml:id="sec-conclusion">
-    <title>Conclusion</title>
-
-    <para>The introduction of the AMD EPYC 9004 Series Classic and AMD EPYC 9004 Series Dense
-      Processors continues to push the boundaries of what is possible for memory and IO-bound
-      workloads with much higher bandwidth and available number of channels. A properly configured
-      and tuned workload can exceed the performance of many contemporary off-the-shelf solutions
-      even when fully customized. The symmetric and balanced nature of the machine makes the task of
-      tuning a workload considerably easier, given that each partition can have symmetric
-      performance. And this is a property that can turn out particularly handy in virtualization, as
-      each virtual machine can be assigned to each one of the partitions.</para>
-
-    <para>With SUSE Linux Enterprise 15 SP4, all the tools to monitor and tune a workload are
-      readily available. You can extract the maximum performance and reliability running your
-      applications on the 4th Generation AMD EPYC Processor platform.</para>
-
-  </sect1>
-
   <sect1 xml:id="sec-amd-epyc2-virtualization">
     <title>Using AMD EPYC 9004 Series Processors for virtualization</title>
 
@@ -3169,6 +3151,24 @@ dmesg | grep SEV
       </para>
 
     </sect2>
+
+  </sect1>
+
+  <sect1 xml:id="sec-conclusion">
+    <title>Conclusion</title>
+
+    <para>The introduction of the AMD EPYC 9004 Series Classic and AMD EPYC 9004 Series Dense
+      Processors continues to push the boundaries of what is possible for memory and IO-bound
+      workloads with much higher bandwidth and available number of channels. A properly configured
+      and tuned workload can exceed the performance of many contemporary off-the-shelf solutions
+      even when fully customized. The symmetric and balanced nature of the machine makes the task of
+      tuning a workload considerably easier, given that each partition can have symmetric
+      performance. And this is a property that can turn out particularly handy in virtualization, as
+      each virtual machine can be assigned to each one of the partitions.</para>
+
+    <para>With SUSE Linux Enterprise 15 SP4, all the tools to monitor and tune a workload are
+      readily available. You can extract the maximum performance and reliability running your
+      applications on the 4th Generation AMD EPYC Processor platform.</para>
 
   </sect1>
 

--- a/xml/MAIN-SBP-AMD-EPYC-5-SLES15SP6.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-5-SLES15SP6.xml
@@ -3374,10 +3374,10 @@ dmesg | grep SEV
         <title>NAS Completion Time - Tuned configuration in 2 VM, with and without SEV</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="EPYC4-nas-2vms-sev.svg" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-nas-2vms-sev.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="EPYC4-nas-2vms-sev.svg" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-nas-2vms-sev.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>

--- a/xml/MAIN-SBP-AMD-EPYC-5-SLES15SP6.xml
+++ b/xml/MAIN-SBP-AMD-EPYC-5-SLES15SP6.xml
@@ -87,6 +87,16 @@
       </author>
       <author>
         <personname>
+          <firstname>Dario</firstname>
+	        <surname>Faggioli</surname>
+        </personname>
+        <affiliation>
+          <jobtitle>Virtualization Specialist</jobtitle>
+          <orgname>SUSE</orgname>
+        </affiliation>
+      </author>
+      <author>
+        <personname>
           <firstname>Kim</firstname>
           <surname>Naru</surname>
         </personname>
@@ -388,7 +398,7 @@ node   0   1
 
     <para>Using policies, a preferred node can be specified where the task will use that node if
       memory is available. This is typically used in combination with binding the task to CPUs on
-      that node. If a workload's memory requirements are larger than a single node and predictable
+      that node. If a workload’s memory requirements are larger than a single node and predictable
       performance is required, then the <quote>interleave</quote> policy will round-robin
       allocations from allowed nodes. This gives suboptimal but predictable access latencies to main
       memory. More importantly, interleaving reduces the probability that the operating system (OS)
@@ -761,7 +771,7 @@ epyc:~ # taskset -c `cat /sys/devices/system/cpu/cpu1/cache/index3/shared_cpu_li
         monitored at a high frequency. This is especially the case if workloads are using large amounts of
         address space, many threads or both. Finally, the <emphasis role="italic">Working Set
         Size (WSS)</emphasis> is the amount of active memory required to complete computations
-        during an arbitrary phase of a program's execution. It is not a value that can be
+        during an arbitrary phase of a program’s execution. It is not a value that can be
         trivially measured. But conceptually it is useful as the interaction between WSS
         relative to available memory affects memory residency and page fault rates.</para>
 
@@ -827,7 +837,7 @@ epyc:~ # taskset -c `cat /sys/devices/system/cpu/cpu1/cache/index3/shared_cpu_li
             <command>node_hit</command> in the statistics. However, if the memory is shared with a
           task running on node 1, all the accesses may be remote, which is a miss from the
           perspective of the hardware but not accounted for in <filename>/proc/vmstat</filename>.
-          Detecting remote and local accesses at the hardware level requires using the hardware's
+          Detecting remote and local accesses at the hardware level requires using the hardware’s
             <emphasis role="italic">Performance Monitoring Unit</emphasis> to detect. See perf-mem(1) for further details.</para>
       </note>
 
@@ -1256,7 +1266,7 @@ Setting cpu: 2
       architecture are those that can be parallelized and are either memory or IO-bound. This
       is particularly true for workloads that are <quote>NUMA friendly</quote>. They can
       be parallelized, and each thread can operate independently for most of the
-      workload's lifetime. For memory-bound workloads, the primary benefit will be taking
+      workload’s lifetime. For memory-bound workloads, the primary benefit will be taking
       advantage of the high bandwidth available on each channel. For IO-bound workloads,
       the primary benefit will be realized when there are multiple storage devices, each
       of which is connected to the node local to a task issuing IO.</para>
@@ -1461,7 +1471,7 @@ epyc:~ # perf script
         addressed by specifying <parameter>-fprefetch-loop-arrays</parameter> and depending
         on whether the workload is store-intensive, <parameter>-mprefetchwt1</parameter>.
         However, care must be taken as an explicitly scheduled prefetch may
-        disable a CPU's predictive algorithms and degrade performance. Similarly, for
+        disable a CPU’s predictive algorithms and degrade performance. Similarly, for
         some workloads branch mispredictions can be a major problem, and in some cases
         breach mispredictions can be offset against I-Cache pressure by specifying
         <parameter>-funroll-loops</parameter>. In the case of STREAM on the test
@@ -1768,7 +1778,7 @@ epyc:~ # perf script
     additional containers or virtual machines to be hosted on the same physical machine
     without CPU contention. Similarly, the degree of parallelization for HPC workloads
     may need to be adjusted. In cases where the workload is tuned based on the number of
-    CCD's, adjustments may be necessary for the changed number of CCDs. An exception are cases
+    CCD’s, adjustments may be necessary for the changed number of CCDs. An exception are cases
     where the workload already hits scaling limits. While tuning based on the different
     number of CCXs is possible, it should only be necessary for applications with very
     strict latency requirements. As the size of the cache per core is halved, partitioning based
@@ -1850,30 +1860,8 @@ epyc:~ # perf script
     <para>Please note.  Zen5 JSON event updates (perf userspace) were added in Linux v6.10 and will be supported in a subsequent SLE release. Support for Zen 4 unified memory controller events (kernel and perf userspace) is expected to be available in a similar timeframe.</para>
   </sect1>
 
-  <sect1 xml:id="sec-conclusion">
-    <title>Conclusion</title>
-
-    <para>The introduction of the AMD EPYC 9005 Series Processors continues to push
-      the boundaries of what is possible for memory and
-      IO-bound workloads with significantly higher bandwidth and an increased number of channels. A
-      properly configured and tuned workload can exceed the performance of many contemporary
-      off-the-shelf solutions even when fully customized. The symmetric and balanced nature
-      of the machine makes the task of tuning a workload considerably easier, given that
-      each partition can have symmetric performance. And this is a property that can turn
-      out particularly handy in virtualization, as each virtual machine can be assigned
-      to each one of the partitions.</para>
-
-    <para>With SUSE Linux Enterprise 15 SP6, all the tools to monitor and tune a workload
-      are readily available. You can extract the maximum performance and
-      reliability running your applications on the 5th Generation AMD EPYC Processor
-      platform.</para>
-
-  </sect1>
-
-
-<!--
   <sect1 xml:id="sec-amd-epyc2-virtualization">
-    <title>Using AMD EPYC 7003 Series Processors for virtualization</title>
+    <title>Using AMD EPYC 9005 Series Processors for virtualization</title>
 
     <para> Running Virtual Machines (VMs) has some aspects in common with running
         <quote>regular</quote> tasks on a host operating system. Therefore, most of the tuning
@@ -1882,7 +1870,7 @@ epyc:~ # perf script
     <para> However, virtualization workloads do pose their own specific challenges and some special
       considerations need to be made, to achieve a better tailored and more effective set of tuning
       advice, for cases where a server is used only as a virtualization host. And this is especially
-      relevant for large systems, such as AMD EPYC 7003 Series Processors. </para>
+      relevant for large systems, such as AMD EPYC 9005 Series Processors. </para>
 
     <para>This is because:</para>
 
@@ -1926,8 +1914,9 @@ epyc:~ # perf script
       and the VMs, in a way that performance comparable to the ones of the host can be achieved. </para>
 
     <para> Both the Kernel-based Virtual Machine (KVM) and the Xen-Project hypervisor (Xen), as
-      available in SUSE Linux Enterprise Server 15 SP2, provide mechanisms to enact this kind of
-      resource partitioning and allocation. </para>
+      available in SUSE Linux Enterprise Server 15 SP6, provide mechanisms to enact this kind of
+      resource partitioning and allocation. Note that this document focuses on the former (KVM), but it
+      includes some <emphasis role="strong">hints</emphasis> about how to deal with the latter as well. </para>
 
     <note>
       <title>Virtual Machine types</title>
@@ -1949,16 +1938,16 @@ epyc:~ # perf script
     <para> No details are given, here, about how to install and configure a system so that it
       becomes a suitable virtualization host. For similar instructions, refer to the SUSE
       documentation at <link
-        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-vt-installation.html"
-        > SUSE Linux Enterprise Server 15 SP2 Virtualization Guide: Installation of Virtualization
+        xlink:href="https://documentation.suse.com/sles/15-SP6/html/SLES-all/cha-vt-installation.html"
+        > SUSE Linux Enterprise Server 15 SP4 Virtualization Guide: Installation of Virtualization
         Components</link>. </para>
 
     <para> The same applies to configuring things such as networking and storage, either for the
       host or for the VMs. For similar instructions, refer to suitable chapters of OS and
       virtualization documentation and manuals. As an example, to know how to assign network
       interfaces (or ports) to one or more VMs, for improved network throughput, refer to <link
-        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-libvirt-config-gui.html#sec-libvirt-config-pci"
-        > SUSE Linux Enterprise Server 15 SP2 Virtualization Guide: Assigning a Host PCI Device to a
+        xlink:href="https://documentation.suse.com/sles/15-SP6/html/SLES-all/cha-libvirt-config-gui.html#sec-libvirt-config-pci"
+        > SUSE Linux Enterprise Server 15 SP6 Virtualization Guide: Assigning a Host PCI Device to a
         VM Guest</link>. </para>
 
     <sect2 xml:id="sec-allocating-resources-hostos">
@@ -1989,13 +1978,11 @@ epyc:~ # perf script
       <para> In terms of CPUs, depending on the workload, it may be fine to use all the physical
         CPUs for the VMs (and this is in fact how the benchmarks in the experimental section of this
         guide have been conducted). On the other hand, if it is necessary to keep some CPUs for the
-        host Os / dom0, we advise to reserve at least one physical core on each NUMA node. If that
-        is not possible, consider reserving at least one core on the NUMA node(s) that have IO
-        channels attached to it (them). In fact, host OS activities are mostly related to performing
-        IO for VMs. It is beneficial for performance if the kernel threads that handle devices can
-        run on the node to which the devices themselves are attached. As an example, in the system
-        shown in <xref linkend="fig-epyc-topology"/>, this would mean reserving at least one
-        physical core for the host OS on node 0. </para>
+        host OS / dom0, we advise to reserve at least one physical core on each NUMA node.
+        This is especially true for a system like the one show in <xref linkend="fig-epyc-topology"/>.
+        In fact, host OS activities are mostly related to performing
+        IO for VMs and it is beneficial for performance if the kernel threads that handle devices can
+        run on the nodes to which the devices themselves are attached, which is both NUMA nodes, in our case. </para>
 
       <para> System administrators need to be able to reach out and login to the system, to monitor,
         manage and troubleshoot it. Therefore, it is possible that even more resources needs to be
@@ -2006,15 +1993,15 @@ epyc:~ # perf script
       <sect3 xml:id="sec-allocating-resources-hostos-kvm">
         <title>Reserving CPUs and memory for the host on KVM</title>
 
-        <para> When using KVM, sparing, for example, 2 cores and 12 GB of RAM for the host OS is
-          done by stopping creating VMs when the total number of vCPUs of all VMs has reached 252
-          (as each core has 2 threads) or when the total cumulative amount of allocated RAM has
-          reached 220 GB. </para>
+        <para> When using KVM, sparing, for example, 32 cores (i.e., one full core for each CCX on both NUMA nodes) and 64 GB of RAM for the host OS is
+          done by stopping creating VMs when the total number of vCPUs of all VMs has reached 448
+          (as each core has 2 threads) and when the total cumulative amount of allocated RAM has
+          reached 690 GB. </para>
 
         <para> To make sure that these CPUs are not used by the virtual machines and are available
           to the host, virtual CPU pinning (discussed later in this document) can be used. There are
           also other ways to enforce this, for example with <package>cgroups</package>, or by means
-          of the <package>isolcpus</package> boot parameter, but we will not cover them in details. </para>
+          of the <package>isolcpus</package> boot parameter, but these are not covered in details within this guide. </para>
 
       </sect3>
 
@@ -2022,20 +2009,20 @@ epyc:~ # perf script
         <title>Reserving CPUs and memory for the host on Xen</title>
 
         <para> When using Xen, dom0 resource allocation needs to be done explicitly at system boot
-          time. For example, assigning 8 physical cores and 12 GB of RAM to it is done by specifying
+          time. For example, assigning 32 physical cores and 64 GB of RAM to it is done by specifying
           the following additional parameters on the hypervisor boot command line (for example, by
           editing <filename>/etc/defaults/grub</filename>, and then updating the boot loader): </para>
 
-        <screen>dom0_mem=12288M,max:12288M dom0_max_vcpus=16</screen>
+        <screen>dom0_mem=65536M,max:65536M dom0_max_vcpus=64</screen>
 
-        <para> The number of vCPUs is 16 because we want Dom0 to have 8 physical cores, and the AMD
-          EPYC 7003 Series Processor has Symmetric multithreading (SMT). 12288M memory (that is 12
+        <para> The number of vCPUs is 64 because we want Dom0 to have 32 physical cores, and the AMD
+          EPYC 9005 Series Processor has Symmetric multithreading (SMT). 65536M memory (that is 64
           GB) is specified both as current and as maximum value, to prevent Dom0 from using
           ballooning (see <link
             xlink:href="https://wiki.xenproject.org/wiki/Tuning_Xen_for_Performance#Memory">
             https://wiki.xenproject.org/wiki/Tuning_Xen_for_Performance#Memory</link> ). </para>
 
-        <para> Making sure that Dom0 vCPUs run on specific pCPUs is not strictly necessary. If
+        <para> Making sure that Dom0 vCPUs run on specific pCPUs is not strictly necessary. However, if
           wanted, it can be enforced acting on the Xen scheduler, when Dom0 is booted (as there is
           currently no mechanism to set up this via Xen boot time parameters). If using the
             <package>xl</package> toolstack, the command is:</para>
@@ -2056,15 +2043,15 @@ epyc:~ # perf script
           those same node(s). When the Dom0 has booted, it is still possible to use <command>xl
             vcpu-pin</command> or <command>virsh vcpupin</command> to change where its vCPUs will be
           scheduled. But the memory will never be moved from where it has been allocated during
-          boot. On AMD EPYC 7003 Series Processors, using this option is not recommended. </para>
+          boot. On AMD EPYC 9005 Series Processors, using this option is not recommended. </para>
 
       </sect3>
 
       <sect3 xml:id="sec-host-cpu-for-intensive-io">
         <title>Reserving CPUs for the host under IO intensive VM workloads</title>
 
-        <para> Covering the cases where VMs run IO intensive workloads, is out of the scope of this
-          guide. As general advice, if IO done in VM is important, it may be appropriate to leave to
+        <para> Tuning the host and the VMs for running IO-intensive workloads is out of the scope of this
+          guide. Just as general advice, if IO done in VM is important, it may be appropriate to leave to
           the host OS either one core or one thread for each IO device used by each VM. If this is
           not possible, for example because it reduces to much the CPUs that remain available for
           running VMs (especially in case the goal is to run many of them), then exploring
@@ -2085,7 +2072,7 @@ epyc:~ # perf script
         entirely devoted to running VMs, Huge Pages are likely not required for host OS processes.
         Actually, in this case, having them active on the host may even negatively affect
         performance, as the THP service daemon (which is there for merging <quote>regular</quote>
-        pages and form Huge Pages) can interfere with VMs' vCPUs execution. For disabling Huge Pages
+        pages and form Huge Pages) can interfere with VMs’ vCPUs execution. For disabling Huge Pages
         for the host OS, in a KVM setup, add the following host kernel command-line option: </para>
 
       <screen>transparent_hugepage=never</screen>
@@ -2102,8 +2089,8 @@ epyc:~ # perf script
 
       <para> The value <parameter>&lt;number of hugepages></parameter> can be computed by taking
         the amount of memory we want to devoted to VMs, and dividing it by the page size (1 GB). For
-        example on our host with 256 GB of RAM, creating 200 Huge Pages means we can accommodate up
-        to 210 GB of VMs' RAM, and leave plenty (~50GB) to the host OS. </para>
+        example on our host with 754 GB of RAM, creating 672 Huge Pages means we can accommodate up
+        to  GB of VMs’ RAM, and leave plenty (~80GB) to the host OS. </para>
 
       <para> On Xen, none of the above is necessary. In fact, Dom0 is a paravirtualized guest, for
         which Huge Pages support is not present. On the other hand, for the memory used for the
@@ -2115,15 +2102,11 @@ epyc:~ # perf script
     <sect2 xml:id="sec-automatic-numa-balancing">
       <title>Automatic NUMA balancing</title>
 
-      <para> On Xen, Automatic NUMA Balancing (NUMAB) in the host OS should be disabled. Dom0 is,
-        currently, a paravirtualized guest without a (virtual) NUMA topology and, thus, NUMAB would
-        be totally useless. </para>
-
       <para> On KVM, NUMAB can be useful in dynamic virtualization scenarios, where VMs are created,
         destroyed and re-created relatively quickly. Or, in general, it can be useful in cases where
         it is not possible or desirable to statically partition the host resources and assign them
         explicitly to VMs. This, however, comes at the price of some latency being introduced. Plus,
-        NUMAB's own operation can interfere with VMs' execution and cause further performance
+        NUMAB’s own operation can interfere with VMs’ execution and cause further performance
         degradation. In any case, this document focuses on achieving the best possible performance
         for VMs, through specific tuning and static resource allocation, therefore it is recommended
         to leave NUMAB turned off. This can be done by adding the following parameter to the host
@@ -2136,6 +2119,9 @@ epyc:~ # perf script
 
       <screen>echo 0 > /proc/sys/kernel/numa_balancing</screen>
 
+      <para> On Xen, Automatic NUMA Balancing (NUMAB) in the host OS should be disabled. Dom0 is,
+        currently, a paravirtualized guest without a (virtual) NUMA topology and, thus, NUMAB would
+        be totally useless. </para>
     </sect2>
 
     <sect2 xml:id="sec-services-daemons-power">
@@ -2147,7 +2133,7 @@ epyc:~ # perf script
       <para> For example, <package>tuned</package> should either not be used, or the profile should
         be set to one that does not implicitly put the CPUs in polling mode. Both
           <package>throughput-performance</package> and <package>virtual-host</package> profiles
-        from SUSE Linux Enterprise Server 15 SP2 are okay, as neither of them touches
+        from SUSE Linux Enterprise Server 15 SP6 are okay, as neither of them touches
           <filename>/dev/cpu_dma_latency</filename>. </para>
 
       <para>
@@ -2176,15 +2162,16 @@ epyc:~ # perf script
     </sect2>
 
     <sect2 xml:id="sec-sev-host">
-      <title>Secure Encrypted Virtualization (SEV)</title>
+      <title>Confidential Computing Technologies (SEV and SEV-ES)</title>
 
-      <para> Secure Encrypted Virtualization (SEV) technology, supported on the 3rd Generation AMD
-        EPYC Processors, allows the memory of the VMs to be encrypted. Enabling it for a VM happens
-        in the VM's own configuration file, but there are preparation steps that needs to occur at
+      <para> Secure Encrypted Virtualization (SEV) and SEV with Encrypted State (SEV-ES) technologies, are available on the 5th Generation AMD
+        EPYC Processors and supported on SUSE Linux Enterprise Server 15 SP6. They allow the memory of the VMs to be encrypted, enabling an high level of
+        confidentiality. SEV-ES is considered superior to plain SEV, as also CPU registers are encrypted when they are saved into the host memory.
+        For using SEV-ES for a VM, we need to enable it in the VM’s own configuration file, but there are preparation steps that needs to occur at
         the host level. </para>
 
       <para> The <package>libvirt</package> documentation contains all the necessary steps required
-        for enabling SEV on a host that supports it. It has been enough to add the following boot
+        for enabling SEV-ES on a host that supports it. It has been enough to add the following boot
         parameters to the host kernel command line, in the boot loader: </para>
 
       <screen>mem_encrypt=on kvm_amd.sev=1</screen>
@@ -2194,20 +2181,27 @@ epyc:~ # perf script
           documentation: Enabling SEV on the host</link>. </para>
 
       <para> It should be noted that, at least as far as the workload analyzed in this document,
-        enabling SEV on the host has not caused any noticeable performance degradation. In fact,
+        enabling SEV-ES on the host has not caused any noticeable performance degradation. In fact,
         running CPU and memory intensive workloads, both on the host and in VMs, with or without the
-        parameters above added to the host kernel boot command line, resulted in indistinguishable
-        results. Therefore, enabling SEV at the host level can be considered safe, from the point of
-        view of not hurting performance of VMs and workloads that will not enable VM memory
-        encryption. Of course, this applies to when SEV is enabled for the host and is
-          <emphasis>not</emphasis> used for encrypting VMs. </para>
+        parameters above, resulted in indistinguishable
+        results. Therefore, enabling SEV-ES at the host level can be considered safe, from the point of
+        view of not hurting performance of VMs and of workloads that will not take advantage of VM memory
+        encryption. </para>
 
-      <para>What happens when SEV is used for encrypting VMs' memory will be described later in the
+      <para>On the other hand, what happens when SEV and SEV-ES are used for encrypting VMs' memory is described later in the
         guide.</para>
 
       <note>
-        <title>SEV on Xen</title>
-        <para>In SUSE Linux Enterprise Server 15 SP2, SEV is not available on Xen.</para>
+        <title>SEV-SNP</title>
+        <para> 5th Generation AMD EPYC Processors come with an even more advanced confidential computing feature, known as
+        SNP, that is also able to guarantee (among other things) the integrity of the VM. Such feature, however, is
+        not officially available and supported on SUSE Linux Enterprise Server 15 SP6, and is therefore not discussed
+        any further in this document (although it is, actually, already usable via an experimental module).</para>
+      </note>
+
+      <note>
+        <title>Encryption on Xen</title>
+        <para>In SUSE Linux Enterprise Server 15 SP6, neither SEV nor SEV-ES (not to mention SNP) are available on Xen.</para>
       </note>
 
     </sect2>
@@ -2219,8 +2213,8 @@ epyc:~ # perf script
 
     <para> For instructions on how to create an initial VM configuration, start the VM, and install
       a guest OS, refer to the SUSE documentation at <link
-        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-kvm-inst.html">
-        SUSE Linux Enterprise Server 15 SP2 Virtualization Guide: Guest Installation</link>. </para>
+        xlink:href="https://documentation.suse.com/sles/15-SP6/html/SLES-all/cha-kvm-inst.html">
+        SUSE Linux Enterprise Server 15 SP6 Virtualization Guide: Guest Installation</link>. </para>
 
     <para>From a VM configuration perspective, the two most important factors for achieving top
       performance on CPU and memory bound workloads are:</para>
@@ -2249,7 +2243,7 @@ epyc:~ # perf script
         importance that the initial placement of the VMs is as optimal as possible. Both Xen and KVM
         can make <quote>educated guesses</quote> on what a good placement might be. For the purpose
         of this document, however, we are interested in what is the absolute best possible initial
-        placement of the VMs, taking into account the specific characteristics of AMD EPYC 7003
+        placement of the VMs, taking into account the specific characteristics of AMD EPYC 9005
         Series Processor systems. And this can only be achieved by <emphasis role="strong"
           >manually</emphasis> doing the initial placement. Of course, this comes at the price of
         reduced flexibility, and is only possible when there is no oversubscription. </para>
@@ -2272,38 +2266,118 @@ epyc:~ # perf script
       </screen>
 
       <para> The <parameter>'strict'</parameter> guarantees that the all memory for the VM will come
-        only from the specified (set of) NUMA node(s) specified in <parameter>nodeset</parameter>. A
+        only from the (set of) NUMA node(s) specified in <parameter>nodeset</parameter>. A
         cell is, in fact, a virtual NUMA node, with <parameter>cellid</parameter> being its ID and
           <parameter>nodeset</parameter> telling exactly from what host physical NUMA node(s) the
-        memory for this virtual node should be allocated. A NUMA-unaware VMs can still include this
+        memory for this virtual node should be allocated.</para>
+
+      <para>The correctness of this kind of tuning can be verified checking on which NUMA node(s)
+        the memory of the QEMU processes representing the VMs have been allocated on, by using the
+        <parameter>numastat</parameter> tool (on the host) like this:</para>
+
+      <screen>
+host:~ # numastat -p qemu-system-x86_64
+Per-node process memory usage (in MBs) for PID 53153 (qemu-system-x86)
+                           Node 0          Node 1           Total
+                  --------------- --------------- ---------------
+Huge                    344064.00       344064.00       688128.00
+Heap                         0.00          150.57          150.57
+Stack                        0.00            0.13            0.13
+Private                    149.59         4522.84         4672.43
+----------------  --------------- --------------- ---------------
+Total                   344213.59       348737.54       692951.12
+      </screen>
+
+      <para>In fact, we see that there is only 1 QEMU process (as there is only
+        1 VM running) and its memory footprint has been equally split between the
+        two NUMA nodes.</para>
+
+      <para>A NUMA-unaware VM can still include this
         element in its configuration file. It will have only one
-          <parameter>&lt;memnode></parameter> element. </para>
+          <parameter>&lt;memnode></parameter> element, and the output of
+        <parameter>numastat</parameter> will look like this:</para>
+
+      <screen>
+host:~ # numastat -p qemu-system-x86_64
+Per-node process memory usage (in MBs)
+PID                               Node 0          Node 1           Total
+-----------------------  --------------- --------------- ---------------
+184717 (qemu-system-x86)       346040.98           19.30       346060.28
+184980 (qemu-system-x86)           19.50       346227.04       346246.54
+-----------------------  --------------- --------------- ---------------
+Total                          346060.48       346246.34       692306.82
+      </screen>
+
+      <para>In this case there are 2 VMs running and their memory have been
+        pretty much entirely allocated on a single NUMA node: <parameter>Node 0</parameter>
+        for the VM associated to the QEMU process with PID <parameter>184717</parameter>,
+        and <parameter>Node 1</parameter> for the other one.
+      </para>
+
+      <para>A similar, but more complex example is also shown below. There are
+        sixteen VMs, and they have been evenly distributed between the two nodes: </para>
+
+      <screen>
+host:~ # numastat -p qemu-system
+
+Per-node process memory usage (in MBs)
+PID                               Node 0          Node 1           Total
+-----------------------  --------------- --------------- ---------------
+200907 (qemu-system-x86)        43635.53           55.60        43691.13
+201027 (qemu-system-x86)        43691.16           55.60        43746.76
+201145 (qemu-system-x86)        43712.86           55.60        43768.46
+201263 (qemu-system-x86)        43712.64           55.60        43768.24
+201380 (qemu-system-x86)        43736.95           55.60        43792.55
+201501 (qemu-system-x86)        43754.32           55.60        43809.93
+201620 (qemu-system-x86)        43690.27           55.60        43745.87
+201737 (qemu-system-x86)        43776.14           55.60        43831.75
+201856 (qemu-system-x86)            0.00        43800.09        43800.09
+201973 (qemu-system-x86)            0.00        43733.63        43733.63
+202090 (qemu-system-x86)            0.00        43765.54        43765.54
+202205 (qemu-system-x86)            0.00        43798.21        43798.21
+202325 (qemu-system-x86)            0.00        43752.20        43752.20
+202450 (qemu-system-x86)            0.00        43759.35        43759.35
+202570 (qemu-system-x86)            0.00        43775.38        43775.38
+202692 (qemu-system-x86)            0.00        43800.96        43800.96
+-----------------------  --------------- --------------- ---------------
+Total                          349709.87       350630.17       700340.04
+      </screen>
 
       <para>Placement of vCPUs happens via the <parameter>&lt;cputune></parameter> element, as
         in the example below:</para>
 
       <screen>
-&lt;vcpu placement='static'>240&lt;/vcpu>
+&lt;vcpu placement='static'>512&lt;/vcpu>
 &lt;cputune>
-  &lt;vcpupin vcpu='0' cpuset='4'/>
-  &lt;vcpupin vcpu='1' cpuset='132'/>
-  &lt;vcpupin vcpu='2' cpuset='5'/>
-  &lt;vcpupin vcpu='3' cpuset='133'/>
-  ...
+    &lt;vcpupin vcpu="0" cpuset="0"/>
+    &lt;vcpupin vcpu="1" cpuset="256"/>
+    &lt;vcpupin vcpu="2" cpuset="1"/>
+    &lt;vcpupin vcpu="3" cpuset="257"/>
+    ...
+    &lt;vcpupin vcpu="256" cpuset="128"/>
+    &lt;vcpupin vcpu="257" cpuset="384"/>
+    &lt;vcpupin vcpu="258" cpuset="129"/>
+    &lt;vcpupin vcpu="259" cpuset="385"/>
+   ...
 &lt;/cputune>
       </screen>
 
-      <para> The value <parameter>240</parameter> means that the VM will have 240 vCPUs. The
+      <para> The value <parameter>512</parameter> means that the VM has 512 vCPUs.
           <parameter>static</parameter> guarantees that each vCPU will stay on the pCPU(s) on which
         it is <quote>pinned</quote> to. The various <parameter>&lt;vcpupin></parameter> elements
         are where the mapping between vCPUs and pCPUs is established (<parameter>vcpu</parameter>
         being the vCPU ID and <parameter>cpuset</parameter> being either one or a list of pCPU IDs). </para>
 
-      <para> To use all of the available 256 pCPUs for a VM, specify <parameter>256</parameter>. In
-        addition to that, though, the following element should be added in the
+      <para> In order to be able to create VMs with more than 255 vCPUs,
+        the following element should be added in the
           <parameter>&lt;device></parameter> section:</para>
 
       <screen>
+&lt;features>
+  ...
+  &lt;ioapic driver="qemu"/>
+&lt;/features>
+...
 &lt;devices>
   ...
   &lt;iommu model='intel'>
@@ -2314,46 +2388,79 @@ epyc:~ # perf script
     </screen>
 
       <para> When pinning vCPUs to pCPUs, adjacent vCPU IDs (like vCPU ID 0 and vCPU ID 1) must be
-        assigned to host SMT siblings (like pCPU 65 and pCPU 193, on our test server). In fact, QEMU
+        assigned to host SMT siblings (like, for instance, pCPU 4 and pCPU 260, on our test server):</para>
+
+      <screen>
+host:~ # cat /sys/devices/system/cpu/cpu4/topology/thread_siblings_list
+4,260
+      </screen>
+
+      <para>In fact, QEMU
         uses a static SMT sibling CPU ID assignment. This is how we guarantee that virtual SMT
-        siblings will always execute on actual physical SMT siblings. </para>
+        siblings will always execute on actual physical SMT siblings: </para>
+
+      <screen>
+vm1:~ # cat /sys/devices/system/cpu/cpu8/topology/thread_siblings_list
+8,9
+    </screen>
 
       <para> The following sections give more specific and precise details about placement of vCPUs
-        and memory for VM of varying sizes of VMs, on the reference system for this guide (see <xref
-          linkend="fig-epyc-topology"/>. </para>
+        and memory for VM of varying sizes, on the reference system for this guide (see <xref
+          linkend="fig-epyc-topology"/>. Note that in SUSE Linux Enterprise 15 SP6, as an enhancement, as compared
+        to previous OS versions, we can actually create VMs as large as our test host is, I.e., a VM with 512 virtual CPUs. </para>
 
       <sect3 xml:id="sec-placement-one-vm">
-        <title>Placement of only one large VM</title>
+        <title>Placement of a single large VM</title>
 
-        <para> An interesting use case when <quote>only one</quote> VM is used. Reasons for doing
+        <para> An interesting use case is when <quote>only one</quote> VM is used. Reasons for doing
           something like that include security/isolation, flexibility, high availability, and
           others. In this cases, typically, the VM is almost as large as the host itself. </para>
 
-        <para> Let us, therefore, consider a VM with all of the 256 vCPUs and 200 GB of RAM. Such VM
+        <para> Let us, therefore, consider a VM with 512 vCPUs and 672 GB of RAM. Such VM
           spans multiple host NUMA nodes and therefore it is recommended to create a virtual NUMA
           topology for it. </para>
 
         <para> We should create a virtual topology with 2 virtual NUMA nodes (that is, as many as
-          there are physical NUMA nodes), and split the VM’s memory equally among them. The 256
-          vCPUs are assigned to the 2 nodes, 128 on each. </para>
-
-        <para> The VM Memory must be split equally among the 2 nodes. At this point, if a suitable
+          there are physical NUMA nodes), and split the VM’s memory equally among them. The 672
+          vCPUs are assigned to the 2 nodes, 336 on each. This way, if a suitable
           virtual topology is also provided to the VM, each of the VM’s vCPUs will access its own
           memory directly, and use Infinity Fabric inter-socket links only to reach foreign memory,
           as it happens on the host. Workloads running inside the VM can be tuned exactly like they
-          were running on a bare metal 3rd Generation AMD EPYC Processor server. </para>
+          were running on a bare metal 5th Generation AMD EPYC Processor server. </para>
 
         <para>The following example <command>numactl</command> output comes from a VM configured as
           explained:</para>
 
         <screen>
+vm1:~ # numactl --hardware
 available: 2 nodes (0-1)
-node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127
-node 0 size: 100670 MB
-node 0 free: 100003 MB
-node 1 cpus: 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255
-node 1 size: 100768 MB
-node 1 free: 100077 MB
+node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
+ 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58
+ 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88
+ 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113
+ 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135
+ 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157
+ 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179
+ 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201
+ 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223
+ 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245
+ 246 247 248 249 250 251 252 253 254 255
+node 0 size: 338489 MB
+node 0 free: 337385 MB
+node 1 cpus: 256 257 258 259 260 261 262 263 264 265 266 267 268 269 270 271 272 273 274
+ 275 276 277 278 279 280 281 282 283 284 285 286 287 288 289 290 291 292 293 294 295 296
+ 297 298 299 300 301 302 303 304 305 306 307 308 309 310 311 312 313 314 315 316 317 318
+ 319 320 321 322 323 324 325 326 327 328 329 330 331 332 333 334 335 336 337 338 339 340
+ 341 342 343 344 345 346 347 348 349 350 351 352 353 354 355 356 357 358 359 360 361 362
+ 363 364 365 366 367 368 369 370 371 372 373 374 375 376 377 378 379 380 381 382 383 384
+ 385 386 387 388 389 390 391 392 393 394 395 396 397 398 399 400 401 402 403 404 405 406
+ 407 408 409 410 411 412 413 414 415 416 417 418 419 420 421 422 423 424 425 426 427 428
+ 429 430 431 432 433 434 435 436 437 438 439 440 441 442 443 444 445 446 447 448 449 450
+ 451 452 453 454 455 456 457 458 459 460 461 462 463 464 465 466 467 468 469 470 471 472
+ 473 474 475 476 477 478 479 480 481 482 483 484 485 486 487 488 489 490 491 492 493 494
+ 495 496 497 498 499 500 501 502 503 504 505 506 507 508 509 510 511
+node 1 size: 338432 MB
+node 1 free: 337252 MB
 node distances:
 node   0   1
   0:  10  32
@@ -2362,46 +2469,48 @@ node   0   1
 
         <para> This is analogous to the host topology, also from the point of view of NUMA node
           distances (as the <package>libvirt</package> version present in SUSE Linux Enterprise
-          Server 15 SP2, allows us to define the virtual nodes distance table). The only differences
-          are the number of CPUs, their APIC IDs and the amount of memory. </para>
+          Server 15 SP6 allows us to define the virtual nodes distance table). The only differences
+          are the APIC IDs of the CPUs and the amount of memory. </para>
 
-        <para>See <xref linkend="sec-appendix-a"/> for an almost complete VM configuration
-          file.</para>
+        <para>See <xref linkend="sec-appendix-a"/> for a complete VM configuration file.</para>
 
-        <para>An alternative setup would be to leave some pCPUs to the host, for example using
-            <quote>only</quote> 240 vCPUs for the VM. As said already, full cores must always be
-          used. That means, assign vCPUs 0 and 1 to Core L#4, vCPUs 2 and 3 to Core L#5, vCPUs 4 and
-          5 to Core L#6, etc. To enact this, we must pin vCPUs 0 and 1 to pCPUs 4 and 132; vCPUs 2
-          and 3 to pCPUs 5 and 133; vCPUs 4 and 5 to pCPUs 6 and 134, etc. And, of course, the two
-          nodes must have the same number of vCPUs. </para>
-
-        <para> In such a setup, cores L#0, L#1, L#2 and L#3 from host NUMA node #0 and cores L#64,
-          L#65, L#66 and L#67 from host NUMA node #1 will be reserved to the host. This, however,
-          means splitting two of the dies, which in turns means there will be some L3 cache
-          interference between the host and the VM. If that damages the performance of the workloads
-          of interest too much, avoid it, by giving to the VM 224 vCPUs. </para>
+        <para>As said already, full cores must always be used. If possible always fully use CCXes/dies too.
+          Since each die has 16 CPUs, that means that a VM with 512 vCPUs will use all the 16 CCXes, on each of the 2 nodes
+          (as 16 x 16 x 2 is indeed 512).
+          So, for instance, vCPUs 0 to 15 can be assigned to Cores L#0 to L#7 (and hence to CPUs P#0 to P#7 and P#256 to P#263), on node P#0;
+          vCPUs 16 to 31 to Cores L#$8 to L#15, and so on (and the same on node P#1).
+          In fact, this is what we call coherent 1-to-1 mapping between virtual and physical topologies.</para>
 
       </sect3>
 
       <sect3 xml:id="sec-placement-two-vms">
         <title>Placement of two large VMs</title>
 
-        <para> If wanting to run two VMs, they can have 128 vCPUs and 100 GB memory each. The
-          recommendation, in this case, is to put each VM on one host NUMA node. This way, VMs no
-          longer span multiple host NUMA nodes, and hence there is no need to define virtual NUMA
-          nodes, as part of their topologies. </para>
+        <para> If wanting to run two VMs, they both can have 256 vCPUs and 336 GB memory each. Therefore, each one can fit in one of the host's NUMA nodes.
+          This also means that there is no need to define virtual NUMA nodes in their configuration.</para>
 
         <para>Placing each VM on one node means that workloads running inside each of them will
           never need to use inter-socket interconnect.</para>
 
-        <para>In this example scenario, the <package>numactl</package> output of both VMs looks as
+        <para>In this example scenario, <package>numactl</package> output of both VMs looks as
           follows:</para>
 
         <screen>
+vm1:~ # numactl --hardware
 available: 1 nodes (0)
-node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127
-node 0 size: 100572 MB
-node 0 free: 100040 MB
+node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28
+ 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58
+ 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88
+ 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113
+ 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135
+ 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157
+ 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179
+ 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201
+ 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223
+ 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245
+ 246 247 248 249 250 251 252 253 254 255
+node 0 size: 338246 MB
+node 0 free: 337317 MB
 node distances:
 node   0
   0:  10
@@ -2410,17 +2519,20 @@ node   0
       </sect3>
 
       <sect3 xml:id="sec-placement-ten-vms">
-        <title>Placement of four to sixteen medium-size VMs</title>
+        <title>Placement of four to thirtytwo medium-size VMs</title>
 
-        <para> Following the same principles, we can <quote>split</quote> each node in 2, and have 4
-          VMs with 64 vCPUs and up to 48 GB of RAM each. </para>
+        <para>Following the same principles, we can <quote>split</quote> each node in 2, and have 4
+          VMs with 128 vCPUs and up to 168 GB of RAM each. It is also feasible to have 8 VMs with
+          64 vCPUs and up to 84 GB of RAM each, 16 VMs with 32 vCPUs and 42 GB RAM, or even
+          32 VMs, all with 16 vCPUs and 21 GB RAM.</para>
 
-        <para> Or even have 16 VMs with 16 vCPUs and 12 GB RAM each. </para>
+        <para>In the first case, each VM will span 8 host dies. In the second and in the third cases, 4 and 2 dies.
+          And in the fourth one, each VM will be pinned to 1 die.</para>
 
-        <para> In both cases, VMs will not need to (and must not) be put across the host NUMA nodes
+        <para> In all these situations, VMs do not need to (and, therefore, should not) be placed across the host NUMA nodes
           boundary, and hence they do not need to be NUMA-aware. They still benefit from having a
-          virtual topology, in terms of cores and threads, which matches the resource they are
-          using. You will find more details about this in following sections. </para>
+          virtual topology, in terms of cores, threads and dies which matches the resource they are
+          using (discussed in more details about in the following section). </para>
 
       </sect3>
 
@@ -2428,29 +2540,38 @@ node   0
         <title>Placement of many small VMs</title>
 
         <para>If small VMs are the target, VMs with either 8, 4 or 2 vCPUs each can be created and
-          efficiently allocated on AMD EPYC 7003 Series Processors servers.</para>
+          efficiently allocated on AMD EPYC 9005 Series Processors servers.</para>
 
-        <para> VMs with 8 vCPUs <quote>occupies</quote> half a dies, and we can have 32 of them. VMs
-          with either 4 or 2 vCPUs will be given 2 and 1 host cores and we can have 64 and 128 of
+        <para> VMs with 8 vCPUs <quote>occupies</quote> half a die, and we can have 64 of them. VMs
+          with either 4 or 2 vCPUs will be given 2 and 1 host cores and we can have 128 and 256 of
           them, respectively. And this is all possible without the need for any of the VMs to span
           more than one host NUMA node. </para>
 
+        <para>Of course, in all these cases, VMs are sharing dies, which means VMs will interfere among each others via the L3 caches.
+          This may or may not be a problem, but there is no way around it, as soon as more VMs than the number of available dies are necessary.
+          The performance impact of such sharing should be tolerable, in most cases, for these configurations, but this needs to be assessed with tests and benchmarks.
+          If that is not the case, then the recommendation is to not go above 32 VMs.
+          More clever (but also more complex) tuning strategies can be designed, but they would require further a-priori knowledge of
+          the workload and/or the load profile of the various VMs, which may not be always available (or can change during the lifecycle
+          of the VMs).</para>
+
         <note>
-          <title>Hundreds of VMs with 256 GB of RAM</title>
+          <title>Hundreds of VMs with limited RAM size and disk sapce</title>
           <para> When the number of VM increases so much, the limiting factor will become the
-            memory. With ~200 GB of RAM available for VMs on our server, we could give only 1 GB of
-            RAM to each of the 128 VMs. Of course, this limitation is only an issue of the system
-            used as reference for this guide. The AMD EPIC 7003 Series Processor architecture itself
+            memory or the disk. With ~700 GB of RAM available for VMs on our server, we can give only 2 GB of
+            RAM to each of the 256 VMs of the last example above. Of course, this limitation is only an issue of the system
+            used as reference for this guide. The AMD EPIC 9005 Series Processor architecture itself
             can accommodate much more RAM. </para>
         </note>
 
         <para> In cases when it is enough or desirable to have VMs with only 1 vCPUs, it is
-          recommended to still not go beyond 128, and assign no less than one full core to each VM.
-          It should be avoided to have vCPUs from different VMs running on two siblings threads of
+          recommended to still not go beyond 256, and assign no less than one full core to each VM.
+          In fact, it should be avoided to have vCPUs from different VMs running on two siblings threads of
           the same core. Such a solution, although functional, is not ideal for all the cases where
-          good and consistent performance within VMs is a goal. What can be done for each VM and for
+          good and consistent performance within VMs is a goal (as well as for security concerns, but that is out of the scope of this guide).
+          What can be done for each VM and for
           each core is to use one of the two threads for the actual vCPU, and the other for its IO
-          thread(s), on the host. This solution allows to take advantage of the full 3rd Generation
+          thread(s), on the host. This solution allows to take advantage of the full 5th Generation
           AMD EPYC processing power. However, we advise to check and verify whether this is a good
           setup and if it brings performance benefits for the specific workloads of interest, before
           committing to it. </para>
@@ -2492,7 +2613,7 @@ node   0
       <note>
         <title>Not covering oversubscribed scenarios</title>
         <para> This guide does not cover in great details oversubscribed scenarios. However, given
-          the large number of CPUs available on an AMD EPYC 7003 Series Processor system and the
+          the large number of CPUs available on an AMD EPYC 9005 Series Processor system and the
           huge amount of memory the architecture supports, this is not considered a limitation.
         </para>
       </note>
@@ -2500,21 +2621,20 @@ node   0
       <bridgehead>CPU Oversubscription</bridgehead>
 
       <para> CPU oversubscription happens when the total cumulative number of vCPUs from all VMs
-        becomes higher than 256. Such situation unavoidably introduces latencies, and leads to lower
+        becomes higher than 512. Such situation unavoidably introduces latencies, and leads to lower
         performance than when host resources are just enough. It is, however, impossible to tell a
         priori by what extent this happens, at least not without a detailed knowledge of the actual
         workload. </para>
 
       <para> If we knew in advance that the load on each vCPU will always stay below 50%, we could
-        assume that even oversubscribing the host by a factor of 2 (like with ~512 vCPUs, in our
+        assume that even oversubscribing the host by a factor of 2 (like with ~1024 vCPUs in total, in our
         case!) will work well. On the other hand, if we knew that the load that each vCPU tries to
         impose on the system is always 100%, creating even 1 vCPUs more than the host has pCPUs
-        would already lead to a misconfiguration. </para>
+        can be considered a misconfiguration. </para>
 
-      <para> When under oversubscription, exclusive 1-to-1 vCPU to pCPU assignment may not the best
-        approach. However, we need to trust the hypervisor scheduler to handle the situation well
-        (which is very likely what will happen). What can be done, though, is to provide the
-        hypervisor scheduler with some <quote>suggestions</quote>, if we have enough knowledge about
+      <para> When oversubscription is necessary, exclusive 1-to-1 vCPU to pCPU assignment may not the best
+        approach and we need to trust the hypervisor scheduler to handle the situation well. What can be done, though, is providing such
+        scheduler at least with some <quote>suggestions</quote>, if we have enough knowledge about
         the workload. For example, we can try to help the scheduler avoiding that all the VMs
         running CPU intensive workloads end on the same nodes, or avoiding cross-node VM migrations
         happening too frequently. </para>
@@ -2553,7 +2673,7 @@ node   0
 
       <bridgehead>Oversubscription with a Single VM</bridgehead>
 
-      <para>This is always considered a misconfiguration. In fact, in some more details:</para>
+      <para>This is always considered a misconfiguration. In fact:</para>
 
       <itemizedlist>
         <listitem>
@@ -2581,30 +2701,29 @@ node   0
         <para>To ensure the VM has a vCPU topology, use the following:</para>
 
         <screen>
-&lt;cpu mode='custom' match='exact' check='none'>
-  &lt;model fallback='allow'>EPYC&lt;/model>
-  &lt;topology sockets='2' cores='64' threads='2'/>
-  &lt;numa>
-    &lt;cell id='0' cpus='0-127' memory='104857600' unit='KiB'>
-      &lt;distances>
-        &lt;sibling id='0' value='10'/>
-        &lt;sibling id='1' value='32'/>
-      &lt;/distances>
-    &lt;/cell>
-    &lt;cell id='1' cpus='128-255' memory='104857600' unit='KiB'>
-      &lt;distances>
-        &lt;sibling id='0' value='32'/>
-        &lt;sibling id='1' value='10'/>
-      &lt;/distances>
-    &lt;/cell>
-   &lt;/numa>
-&lt;/cpu>
+    &lt;cpu mode="host-model" check="none">
+    &lt;topology sockets="2" dies="16" cores="8" threads="2"/>
+    &lt;numa>
+      &lt;cell id="0" cpus="0-255" memory="352321536" unit="KiB">
+        &lt;distances>
+          &lt;sibling id="0" value="10"/>
+          &lt;sibling id="1" value="32"/>
+        &lt;/distances>
+      &lt;/cell>
+      &lt;cell id="1" cpus="256-511" memory="352321536" unit="KiB">
+        &lt;distances>
+          &lt;sibling id="0" value="32"/>
+          &lt;sibling id="1" value="10"/>
+        &lt;/distances>
+      &lt;/cell>
+    &lt;/numa>
+  &lt;/cpu>
         </screen>
 
         <para> The <parameter>&lt;topology></parameter> element specifies the CPU
           characteristics. In this case, we are creating vCPUs which will be seen by the guest OS as
-          being arranged in 2 sockets, each of which has 64 cores, each of which has 2 threads. And
-          this is how we match, for the one big VM, the topology of the host. </para>
+          being arranged in 2 sockets, each of which has 16 dies, each of which has 8 cores with 2 threads (i.e., 16 CPUs).
+          And this is how we match, for the one big VM, the topology of the host. </para>
 
         <para> Each <parameter>&lt;cell></parameter> element defines one virtual NUMA node,
           specifying how much memory and which vCPUs are part of it. The
@@ -2615,109 +2734,189 @@ node   0
 
         <para> CPU model is how the VM is told what type of vCPUs should be <quote>emulated</quote>,
           for example, what features and special instructions and extensions will be available. To
-          achieve best performance, using <parameter>mode='host-passthrough'</parameter> is often
-          the right choice. However, at least on SUSE Linux Enterprise Server 15 SP2, this produces
+          achieve best performance, using <parameter>model='host-passthrough'</parameter> is often
+          the right choice. However, at least on SUSE Linux Enterprise Server 15 SP6, this produces
           wrong results. In fact, such setting prevents the topology - despite it being described
           correctly in the <parameter>&lt;topology></parameter> element - from being interpreted
           correctly, inside the VM. This is visible in the output of the command
             <command>lscpu</command>: </para>
 
         <screen>
+vm1:~ # lscpu
 ...
-CPU(s):              256
-On-line CPU(s) list: 0-255
-Thread(s) per core:  1
-Core(s) per socket:  128
-Socket(s):           2
-NUMA node(s):        2
+CPU(s):                   512
+  On-line CPU(s) list:    0-511
+Vendor ID:                AuthenticAMD
+  Model name:             AMD EPYC 9755 128-Core Processor
+    CPU family:           26
+    Model:                2
+    Thread(s) per core:   1
+    Core(s) per socket:   512
+    Socket(s):            1
 ...
-L1d cache:           64K
-L1i cache:           64K
-L2 cache:            512K
-L3 cache:            16384K
-NUMA node0 CPU(s):   0-127
-NUMA node1 CPU(s):   128-255
+Caches (sum of all):
+  L1d:                    32 MiB (512 instances)
+  L1i:                    32 MiB (512 instances)
+  L2:                     256 MiB (512 instances)
+  L3:                     8 GiB (512 instances)
 ...
-        </screen>
+       </screen>
 
-        <para> Benchmarks have shown that misunderstanding the CPUs as being all individual cores,
-          without there being SMT, has a negative impact on performance. Note that the problem not
-          only involves CPU topology, it is also the cache hierarchy structure which is not
-          constructed consistently with the host. In fact, while the sizes of L1d and L1i caches is
-          wrong (it is 64k instead than 32k, see <xref linkend="fig-epyc-topology"/>). It is also
-          the information about which CPUs share what caches that is completely misconfigured, as
-          shown here: </para>
+        <para>Both the CPU topology and the cache layout, as seen from inside of the VM, are completely wrong, and can affect performance of applications running inside the VM.
+          In fact, not only the sizes of the various cache levels are wrong. It is also the information about which CPUs share what caches that is completely misconfigured, as shown also here: </para>
 
         <screen>
-cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
 0
-cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
 0
-cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
 0
-cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
-0-128
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-255
         </screen>
 
-        <para> The VM thinks that L1d, L1i and L2 are private of each vCPU. That is not the case, as
+        <para> The VM thinks that L1d, L1i and L2 are private of each vCPU, while that is not the case, as
           they are shared by the two threads of each core. Even worse, it thinks that L3 is shared
-          across all the vCPUs of a socket, which is not true, as it is shared only among 8 cores
+          across all the vCPUs of a socket (and that there is only one socket!), which is not true, as it is shared only among 8 cores
           (that is 16 vCPUs). </para>
 
-        <para> For this reason, the recommendation is to use <parameter>EPYC</parameter> as the CPU
-          model (as a 3rd Generation AMD EPYC Processor model is not yet available). This enables a
-          virtual topology inside the VM what is more consistent (although not perfectly identical)
-          with the one of the host, and benchmark shows a beneficial effect on performance coming
-          from that. The output of <command>lscpu</command> with <parameter>EPYC</parameter> as a
+        <para> For this reason, the recommendation is to use <parameter>EPYC-Genoa</parameter> as the CPU
+          model (as an appropriate model for 5th Generation AMD EPYC Processors is not yet available) either manually or by using <parameter>model='host-model'</parameter>.
+          This enables a virtual topology inside the VM what is more consistent (although not perfectly identical)
+          with the one of the host, and benchmarks show a beneficial effect on performance coming
+          from that. The output of <command>lscpu</command> with <parameter>EPYC-Genoa</parameter> as a
           model is shown below: </para>
 
         <screen>
+vm1:~ # lscpu
 ...
-CPU(s):              256
-On-line CPU(s) list: 0-255
-Thread(s) per core:  2
-Core(s) per socket:  64
-Socket(s):           2
-NUMA node(s):        2
+CPU(s):                   512
+  On-line CPU(s) list:    0-511
+Vendor ID:                AuthenticAMD
+  Model name:             AMD EPYC-Genoa Processor
+    CPU family:           25
+    Model:                17
+    Thread(s) per core:   2
+    Core(s) per socket:   128
+    Socket(s):            2
 ...
-L1d cache:           32K
-L1i cache:           64K
-L2 cache:            512K
-L3 cache:            8192K
-NUMA node0 CPU(s):   0-127
-NUMA node1 CPU(s):   128-255
+Caches (sum of all):
+  L1d:                    8 MiB (256 instances)
+  L1i:                    8 MiB (256 instances)
+  L2:                     256 MiB (256 instances)
+  L3:                     1 GiB (32 instances)
 ...
         </screen>
 
-        <para> Now it is the cache sizes that are slightly off, with regard to the host value. And
+        <para>Of course, now it is the <parameter>Model name:</parameter> that is not completely correct.
+          But both the CPU and caches layout is much more in line with what we wanted to achieve by tuning the VM configuration.</para>
+
+        <para>In fact, even if the cache sizes that are slightly off, with regard to the host value. And
           this is because they are the values taken from previous generation AMD EPYC Processors
           architecture characteristics. But the cache topology and cache level sharing among vCPUs
-          are now closer to the host ones (not perfectly, as <parameter>index3</parameter> should
-          report <parameter>0-15</parameter>). This is far more important for achieving performance
-          inside the VM that matches the one of the host. This is shown here: </para>
+          are now correct (as shown below). And this is far more important for achieving good performance
+          inside the VM. </para>
 
         <screen>
-cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
 0-1
-cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
 0-1
-cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
 0-1
-cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
-0-7
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-15
         </screen>
 
-        <para>Related to this, on SUSE Linux Enterprise Server 15 SP2 it would be possible to use
-          the <parameter>haltpoll</parameter> CPU-Idle governor, inside the VM. This is an
-          optimization meant at reducing the number of context switches from the VM and the host
-          (also known as VMExits), when doing static resource partitioning of the host itself. It is
-          would therefore be recommended here, but the problem is that it can be enabled only if the
-          CPU model used is <parameter>host-passthrough</parameter>.</para>
+        <para>Note that, in order to achieve the outcome shown above, it is very important to use the following CPU topology description string, in the VM configuration:</para>
 
-        <para>We therefore recommend to not use it in a SUSE Linux Enterprise Server 15 SP2 VM
-          running on an AMD EPYC 7003 Series Processors, until the inaccurate vCPU topology problem
-          is resolved (and an investigation is ongoing for figuring out how to best address the
-          problem).</para>
+        <screen>&lt;topology sockets="2" dies="16" cores="8" threads="2"/></screen>
+
+        <para>In particular, do not omit the <parameter>dies="16"</parameter> element, as that is what enables the VM to see its vCPUs grouped in dies (the CCXes of the host).
+          In fact, using something like this <parameter>&lt;topology sockets="2" cores="128" threads="2"/></parameter> would result in a correct CPU topology, but the representation of the cache layout would still be inaccurate, such as:</para>
+
+        <screen>
+vm1:~ # lscpu
+...
+CPU(s):                   512
+  On-line CPU(s) list:    0-511
+Vendor ID:                AuthenticAMD
+  Model name:             AMD EPYC-Genoa Processor
+    CPU family:           25
+    Model:                17
+    Thread(s) per core:   2
+    Core(s) per socket:   128
+    Socket(s):            2
+...
+Caches (sum of all):
+  L1d:                    8 MiB (256 instances)
+  L1i:                    8 MiB (256 instances)
+  L2:                     256 MiB (256 instances)
+  L3:                     64 MiB (2 instances)
+...
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-255
+...
+        </screen>
+
+        <para>As a further example, in case we have two VMs, one for each NUMA node and with 256 vCPUs each, both are also configured to have 16 dies (but, of course, just 1 socket), like this:</para>
+
+        <screen>&lt;topology sockets="1" dies="16" cores="8" threads="2"/></screen>
+
+        <para>And the topology, from inside each VM, will look as follows:</para>
+
+        <screen>
+vm1:~ # lscpu
+...
+CPU(s):                   256
+  On-line CPU(s) list:    0-255
+Vendor ID:                AuthenticAMD
+  Model name:             AMD EPYC-Genoa Processor
+    CPU family:           25
+    Model:                17
+    Thread(s) per core:   2
+    Core(s) per socket:   128
+    Socket(s):            1
+...
+Caches (sum of all):
+  L1d:                    4 MiB (128 instances)
+  L1i:                    4 MiB (128 instances)
+  L2:                     128 MiB (128 instances)
+  L3:                     512 MiB (16 instances)
+...
+
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index0/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index1/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index2/shared_cpu_list
+0-1
+vm1:~ # cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
+0-15
+        </screen>
+
+        <para>Finally, on SUSE Linux Enterprise Server 15 SP6 it is possible to select
+          the <parameter>haltpoll</parameter> CPU-Idle governor, inside the VM, even if we are using <parameter>model='host-model'</parameter>
+          (although, it is only partially effective, as <parameter>model='host-passthourgh'</parameter> would be necessary
+          in order for the VM to be able to exploit this feature at its full potential).</para>
+
+        <para>This is an optimization meant at reducing the number of context switches between the VM and the host
+          (also known as VMExits), when doing static resource partitioning of the host itself.
+          For that reason, it is something that we recommend using, although the actual benefit provides highly
+          depends on the workload running inside of the VM.</para>
+
+        <para>For enabling it, just load the kernel module (inside of the VM, of course): </para>
+
+        <screen>
+vm1:~ # modprobe cpuidle-haltpoll
+        </screen>
 
       </sect3>
 
@@ -2725,26 +2924,42 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
       <sect3 xml:id="sec-memory-backing">
         <title>Memory backing</title>
 
-        <para> Memory wise, the VMs need to be told to use the Huge Pages that were reserved for
+        <para> Memory wise, the VMs must be told to use the Huge Pages that were reserved for
           them. To effectively use 1 GB huge pages, the amount of memory each VM is given must be a
           multiple of 1 GB. Also, KSM should be disabled and we also must ensure that VMs' memory is
-          never going to be swapped out. This is all achieved as follows: </para>
+          never going to be swapped out. This is all achieved as follows:</para>
 
         <screen>
-&lt;memory unit='KiB'>209715200&lt;/memory>
+&lt;memory unit='KiB'>704643072&lt;/memory>
 &lt;memoryBacking>
   &lt;hugepages>
-    &lt;page size='209715200' unit='KiB'/>
+    &lt;page size='1' unit='GiB'/>
   &lt;/hugepages>
   &lt;nosharepages/>
-  &lt;locked/>
 &lt;/memoryBacking>
+        </screen>
+
+        <para>In order to verify that the appropriate type of memory is being used by the VMs,
+          one can check the content of <parameter>/proc/meminfo</parameter>, with the VMs running,
+          and observe that all the pre-allocated Huge Pages are actually occupied.</para>
+
+        <screen>
+host:~ # cat /proc/meminfo | grep Huge
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+FileHugePages:         0 kB
+HugePages_Total:     672
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:    1048576 kB
+Hugetlb:       704643072 kB
         </screen>
 
         <note>
           <title>Huge Pages, shared pages and locked pages on Xen</title>
           <para> On Xen, for HVM guests, huge pages are used by default and there is neither any
-            page sharing nor swapping (at least not in SUSE Linux Enterprise Server 15 SP1).
+            page sharing nor swapping (at least not in SUSE Linux Enterprise Server 15 SP6).
             Therefore, the entire <parameter>&lt;memoryBacking></parameter> element is
             technically not necessary. </para>
         </note>
@@ -2760,8 +2975,8 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
           memory ballooning is done as follows: </para>
 
         <screen>
-&lt;memory unit='KiB'>209715200&lt;/memory>
-&lt;currentMemory unit='KiB'>209715200&lt;/currentMemory>
+&lt;memory unit='KiB'>704643072&lt;/memory>
+&lt;currentMemory unit='KiB'>704643072&lt;/currentMemory>
         </screen>
 
         <para> That is, by specifying in the <parameter>&lt;currentMemory></parameter> the same
@@ -2802,9 +3017,9 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
     </sect2>
 
     <sect2 xml:id="sec-sev-vm">
-      <title>Secure Encrypted Virtualization</title>
+      <title>Secure Encrypted Virtualization with Encrypted State</title>
 
-      <para>The following documents</para>
+      <para>The following documents:</para>
       <itemizedlist>
         <listitem>
           <para>
@@ -2815,60 +3030,47 @@ cat /sys/devices/system/cpu/cpu0/cache/index3/shared_cpu_list
         <listitem>
           <para>
             <link
-              xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-amd-sev/art-amd-sev.html"
-              > SUSE Linux Enterprise Server 15 SP2: AMD Secure Encrypted Virtualization (AMD-SEV)
+              xlink:href="https://documentation.suse.com/sles/15-SP4/html/SLES-amd-sev/article-amd-sev.html"
+              > SUSE Linux Enterprise Server 15 SP4: AMD Secure Encrypted Virtualization (AMD-SEV)
               Guide</link>
           </para>
         </listitem>
       </itemizedlist>
-      <para>provide details on how to configure a VM to use AMD SEV (on an AMD SEV capable and
-        properly configured host). Therefore, this section will not go into details. It only lists
-        the entries that are required to add to or change the configuration file. </para>
+      <para>Explain how to configure a VM to use AMD SEV-ES (on an AMD SEV-ES capable and
+        properly configured host) is not in the scope of this document. Refer to the linked materials for the details. </para>
 
-      <para>First of all, a <parameter>&lt;launchSecurity></parameter> stanza must be
-        added:</para>
+      <para>It is possible to check if the host is properly configured to run SEV-ES VMs with the following command:</para>
 
       <screen>
-&lt;launchSecurity type='sev'>
-  &lt;cbitpos>51&lt;/cbitpos>
-  &lt;reducedPhysBits>1&lt;/reducedPhysBits>
-  &lt;policy>0x0003&lt;/policy>
-&lt;/launchSecurity>
+[    0.000000] SEV-SNP: Memory for the RMP table has not been reserved by BIOS
+[   33.954913] ccp 0000:55:00.5: SEV API:1.55 build:40
+[   33.983047] ccp 0000:55:00.5: SEV API:1.55 build:40
+[   41.100388] kvm_amd: SEV enabled (ASIDs 36 - 1006)
+[   41.106817] kvm_amd: SEV-ES enabled (ASIDs 1 - 35)
       </screen>
 
-      <para>Two other things are that the QEMU machine type used for the VM should be
-          <parameter>Q35</parameter> and that a UEFI must be used:</para>
+      <para>Once inside of the VM, this is how one can check whether it is only the memory that is being encrypted (with SEV):</para>
 
       <screen>
-&lt;os>
-  &lt;type arch='x86_64' machine='pc-q35-3.1'>hvm&lt;/type>
-  &lt;loader readonly='yes' type='pflash'>/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin&lt;/loader>
-  &lt;nvram>/var/lib/libvirt/qemu/nvram/sle15sp1-vm1-sev_VARS.fd&lt;/nvram>
-&lt;/os>
+dmesg | grep SEV
+[    0.069436] AMD Memory Encryption Features active: SEV
       </screen>
 
-      <para> Note that on SUSE Linux Enterprise Server 15 SP2, an SEV-enabled VM can use 1 GB Huge
-        Pages memory, preallocated at boot time, the same as when SEV is not enabled as they are
-        allocated during boot.</para>
-
-      <para>Finally, any device that uses <parameter>'virtio'</parameter> needs to gain an XML
-        element looking like: <parameter>&lt;driver iommu='on'/></parameter></para>
-
-      <para>At this point, we can create and start a VM with its memory encrypted, through AMD SEV
-        technology:</para>
+      <para>Or if we are also fully encrypting the VM state (with SEV-ES):</para>
 
       <screen>
-dmesg |grep SEV
-[    0.004000] AMD Secure Encrypted Virtualization (SEV) active
+dmesg | grep SEV
+[    0.069436] AMD Memory Encryption Features active: SEV SEV-ES
       </screen>
 
       <bridgehead>SEV and The IOMMU Device</bridgehead>
 
-      <para>In our experiments, for having a functional VM with SEV enabled, we had to remove the
+      <para>Note that it is not possible to provide a virtual IOMMU device to an encrypted VM.
+        This means that, for having a functional SEV or SEV-ES VM, we need to remove the
           <parameter>iommu</parameter> element, in the <parameter>&lt;device></parameter>
-        section of the VM configuration. Since that element was necessary for having more than 255
+        section of the VM configuration. And since that element is necessary for having more than 255
         vCPUs in the VM, all the experiments conducted with SEV enabled have been done in VMs with
-        at most 248 vCPUs.</para>
+        at most 128 vCPUs.</para>
 
     </sect2>
 
@@ -2884,49 +3086,60 @@ dmesg |grep SEV
       <title>Test scenario: One large VM</title>
 
       <para><xref linkend="fig-stream-bm-vm"/> shows the bandwidth achieved by STREAM when the
-        benchmark is built in single thread mode (single) or parallelized with OpenMP
-        (omp-llcs-spread). For both cases, we compare the results achieved on the host (BM) and
-        inside one VM (VM). </para>
+        benchmark is built in single thread mode ('single') or parallelized with OpenMP
+        ('ompenmp'). For both cases, we compare the results achieved on the host ('BM') and
+        inside one VM ('VM'). </para>
 
 
       <figure xml:id="fig-stream-bm-vm">
         <title>STREAM Bandwidth - Bare metal compared with one VM</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-bm-1vm.svg" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-bm-1vm.svg" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para> As the VM has approximately the same dimension and topology of the host, the same
-        STREAM configuration parameters used in <xref linkend="sec-workload-stream"/>, are used also
-        here. </para>
+      <para>Both the single thread and the parallel results are basically identical (within 1% difference!) between baremetal (blue and yellow rectangles)
+        and inside of the VM (orange and green rectangles), for all the operations (<parameter>Copy</parameter>, <parameter>Scale</parameter>, <parameter>Add</parameter> and
+        <parameter>Triadd</parameter>) of the benchmark.
+      </para>
 
-      <para> We can clearly see how proper tuning allows a VM running on an AMD EPYC 7003 Series
-        Processor server to achieve a memory bandwidth performance within 1% of the one of the host. </para>
+      <para> This clearly shows how proper tuning allows a single VM running on an AMD EPYC 7005 Series
+        Processor server to achieve a memory bandwidth that matches the one that we can reach directly on the host. </para>
 
-      <para><xref linkend="fig-stream-single-1vm-model"/> and <xref linkend="fig-stream-bm-vm"/>
-        show the effect of using different CPU models for the virtual machine. While with single
-        threaded STREAM it seems that CPU model is not a really important parameter, the OpenMP run
-        clearly show how the using the host-passthrough dramatically decreases the performance. </para>
+      <note>
+        <para>Inside of the VM, the STREAM benchmark was configured almost identically to what has been
+         shown already in <xref linkend="sec-workload-stream"/>. </para>
+      </note>
 
-      <para>This seems counter-intuitive, as using host-passthrough and enabling the
-          <parameter>haltpoll</parameter> governor inside the guest is meant to provide the absolute
-        best performance when doing static host resource partitioning, as we are doing here.
-        However, we know that in our case this is because of the inaccurate cache hierarchy exposed
-        to the VM that this causes. </para>
+      <para><xref linkend="fig-stream-single-1vm-model"/> and <xref linkend="fig-stream-omp-1vm-model"/>
+        show the effect of using different CPU models for the virtual machine. We see that, as long as
+        a single thread is used, the CPU model chosen for the VM is completely irrelevant.</para>
+
+      <para>On the other hand, the OpenMP run clearly shows some problems when the <parameter>host-passthrough</parameter> CPU model
+        is selected. In fact, since using that model builds a VM with only 2 LLCs (and also because of the other problems with the cache topology),
+        running STREAM with twice as many threads as there are LLCs in the system results in the benchmark spawning only 4 of them (yellow and green rectangles).
+        And this, of course, dramatically reduces the performance. We can also see that, if we instead manually set the number of threads
+        to the value that we know to be the best for this VM (i.e., 64, dark red and cyan rectangles) performance are restored to how good
+        we know things can be from <xref linkend="fig-stream-bm-vm"/> (and from the <parameter>cpumodel</parameter> results, i.e. the blue and orange rectangles).</para>
+
+      <para>It is also interesting to note that with <parameter>cpumodel+haltpoll</parameter> (orange rectangles) we reach the same performance of the configuration
+        that should theoretically be the absolute best one (<parameter>cpupassthrough+haltpoll (64 threads)</parameter>, cyan rectangle). This means that it is fine
+        to stick with the former, and it is not worthwhile setting <parameter>cpupassthrough</parameter> and coping manually with the misconfigured cache hierarchy inside of the VM
+        (as that could potentially be much more complicated it has been here for the STREAM benchmark or, sometimes, even impossible). </para>
 
       <figure xml:id="fig-stream-single-1vm-model">
         <title>STREAM Bandwidth - Single thread in one VM with different CPU models</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-single-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-single-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-single-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-single-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
@@ -2935,21 +3148,22 @@ dmesg |grep SEV
         <title>STREAM Bandwidth - OpenMP in one VM with different CPU models</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-omp-llcs-spread-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-omp-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-omp-llcs-spread-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-omp-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para>This confirms the need to always run benchmarks for assessing the performance of the
+      <para>This situation also confirms the need to always run benchmarks for assessing the performance of the
         relevant workloads, on a given platform. In fact, because of specific characteristics of
         some components of the virtualization stack available in SUSE Linux Enterprise Server 15
-        SP2, the <parameter>EPYC</parameter> CPU model (host-model) is preferable to what it would
-        have appeared to be the most obvious choice, which is the
-          <parameter>host-passthrough</parameter>. CPU model with <parameter>haltpoll</parameter>
-        governor enabled inside the guest.</para>
+        SP4, the <parameter>EPYC-Milan</parameter> (or, equivalently, the <parameter>host-model</parameter>) CPU model
+        might be preferable to what it would have appeared to be the most obvious choice (<parameter>host-passthrough</parameter>).</para>
+
+      <para>Finally, about the CPUIdle <parameter>haltpoll</parameter> governor, it is recommended to enable and make use of it,
+        although for STREAM (and we can guess also for other, similar, memory intensive benchmarks) it introduces no significant performance difference.</para>
 
     </sect2>
 
@@ -2957,84 +3171,119 @@ dmesg |grep SEV
       <title>Test scenario: Multiple VMs</title>
 
       <para>
-        <xref linkend="sec-virt-test-stream-sev"/> shows what happens when two or four large VMs are
-        used, both with the recommended tuning applied (performance of 1 VM is also displayed, for
-        reference). The graph reports the average memory bandwidth achieved in each experiments,
-        considering all the VMs involved. For example, the light blue bar (4 VMS) is relative to an
-        experiment where four VMs were used and represents the average of the four different memory
-        bandwidth values, one for each of the VMs. </para>
+        <xref linkend="fig-stream-single-vms-avg"/> and <xref linkend="fig-stream-single-vms-sum"/> show what happens when 1, 2, 4, 8, 16 and 32 VMs are used.
+        The former reports the average bandwidth achieved in each experiments, considering all the VMs involved. For example, the yellow blue bar (4 VMS) is relative to an
+        experiment where 4 VMs were concurrently running the STREAM benchmark (in single thread mode) and represents the average of the 4 different memory bandwidth values,
+        one for each of such VMs.
+        The latter shows something similar, but the bars represents the cumulative STREAM bandwidth achieved in each experiments, considering all the VMs involved.
+        For example, the cyan bar (32 VMs) is relative to an experiment where 32 VMs were concurrently running the STREAM benchmark (in single thread mode) and represents the sum
+        of the 24 different memory bandwidth values, one of each of such VMs.
+      </para>
 
-      <figure xml:id="fig-stream-omp-llcs-spread-vms-avgstd">
-        <title>STREAM Bandwidth - OpenMP, per-VM average when using multiple VMs</title>
+      <figure xml:id="fig-stream-single-vms-avg">
+        <title>STREAM Bandwidth - Single, average of the bandwidth achieved among all VMs of each group</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-omp-llcs-spread-vms-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-single-vms-avg.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-omp-llcs-spread-vms-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-stream-single-vms-avg.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para>We can see that performance scales down in a close to linear fashion, with the increase
-        of the number of VMs involved (although, not perfectly linear for all the type of STREAM
-        operations). </para>
+      <figure xml:id="fig-stream-single-vms-sum">
+        <title>STREAM Bandwidth - Single, sum of the bandwidth achieved within all VMs of each group</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="EPYC5-stream-single-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="EPYC5-stream-single-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <para>We see in <xref linkend="fig-stream-single-vms-avg"/> how the single STREAM bandwidth suffers a bit of a decline as more VMs are packed on the NUMA nodes and, hence,
+        compete for the bandwith of the memory controllers. However,
+         <xref linkend="fig-stream-single-vms-sum"/> reminds us how the total bandwidth achieved, if we consider all the VMs involved in each experiments, actually goes up (and
+        it scales roughly linearly, at least for some of the STREAM operations),
+        until it reaches the same level that we know (e.g., from <xref linkend="fig-stream-bm-vm"/>) it can touch.
+      </para>
+
+      <para><xref linkend="fig-stream-omp-vms-avg"/> and <xref linkend="fig-stream-omp-vms-sum"/> show the same, but when the parallel (via OpenMP) version of STREAM
+        is run, inside of each VM of each experiment.</para>
+
+      <figure xml:id="fig-stream-omp-vms-avg">
+        <title>STREAM Bandwidth - OpenMP, average of the bandwidth achieved among all VMs of each group</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="EPYC5-stream-omp-vms-avg.svg" width="80%" format="PNG"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="EPYC5-stream-omp-vms-avg.svg" width="80%" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <figure xml:id="fig-stream-omp-vms-sum">
+        <title>STREAM Bandwidth - OpenMP, sum of the bandwidth achieved within all VMs of each group</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="EPYC5-stream-omp-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="EPYC5-stream-omp-vms-sum.svg" width="80%" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <para>In <xref linkend="fig-stream-omp-vms-avg"/> we see that performance scales down in a close to linear fashion with the increase
+        of the number of VMs involved (although, not perfectly linearly for all the type of STREAM operations).
+        At the same time, <xref linkend="fig-stream-omp-vms-sum"/> shows how the total cumulative bandwidth of each experiments stays pretty much always at its top levels,
+        as one would expect. Actually, it even seems that using many small VMs may make it possible to exploit even better (as compared to what happens when few large
+        VMs are running) the large memory bandwidth provided by the memory controllers of the AMD EPYC 9005 Series Processors.
+      </para>
 
     </sect2>
 
     <sect2 xml:id="sec-virt-test-stream-sev">
       <title>Test scenario: Secure Encrypted Virtualization</title>
 
-      <para>The goal for this test was evaluating the impact on the performance of SEV, on a memory
+      <para>The goal for this test was evaluating the impact on the performance of encrypting the VMs with SEV and with SEV-ES, when running a memory
         intensive workload like STREAM.</para>
 
-      <para> We can evaluate that looking at the results of running single threaded and parallelized
-        STREAM in one VM (in <xref linkend="fig-stream-1vms-sev-avg"/>), in two VMs (in <xref
-          linkend="fig-stream-2vms-sev-avg"/>) and in four VMs *in <xref
-          linkend="fig-stream-4vms-sev-avg"/>) running concurrently, both when SEV is disabled
-        (no-SEV) and when it is enabled (SEV). They again report the average of the bandwidth values
-        of each VM that was running in the particular experiment. </para>
+      <para>Considering the case when 4 VMs are concurrently running on the host and are executing the STREAM benchmark, <xref linkend="fig-stream-single-sev"/>
+        shows the average bandwidth of the single thread execution of the benchmark in both such VMs when memory is not encrypted (blue bars), when memory is
+        encrypted with SEV (orange bar) and with both memory and state are encrypted with SEV-ES (yellow bar).</para>
 
-      <figure xml:id="fig-stream-1vms-sev-avg">
-        <title>STREAM Bandwidth - Single and OpenMP, with and without SEV in 1 VM</title>
+      <figure xml:id="fig-stream-single-sev">
+        <title>STREAM Bandwidth - Single, average bandwidth in 4 VMs when unencrypted, encrypted with SEV and with SEV-ES</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-1vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-1vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-single-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <figure xml:id="fig-stream-2vms-sev-avg">
-        <title>STREAM Bandwidth - Single and OpenMP, with and without SEV in 2 VMs</title>
+      <figure xml:id="fig-stream-openmp-sev">
+        <title>STREAM Bandwidth - OpenMP, average bandwidth in 4 VMs when unencrypted, encrypted with SEV and with SEV-ES</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="stream-2vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-openmp-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="stream-2vms-sev-avg.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-stream-openmp-sev-avg.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <figure xml:id="fig-stream-4vms-sev-avg">
-        <title>NAS Completion Time - Baremetal and in one VM, different configurations</title>
-        <mediaobject>
-          <imageobject role="fo">
-            <imagedata fileref="stream-4vms-sev-avg.png" width="80%" format="PNG"/>
-          </imageobject>
-          <imageobject role="html">
-            <imagedata fileref="stream-4vms-sev-avg.png" width="80%" format="PNG"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-
-      <para>It is quite evident that enabling SEV has only a very limited impact on the performance
-        for this workload, which is within 2% and 4% for most of the experiments. Even in the case
-        where the overhead is the highest (OpenMP Stream run inside 4 VMs), the performance decrease
-        is limited to around 6%.</para>
+      <para>It is quite evident how both SEV and SEV-ES have a close to nonexistent impact on the performance
+        for this workload. Actually, it may even seem that, in the OpenMP case, encrypted VMs are faster, but we
+        should note how all the results fall within the other ones’ error bars.</para>
 
     </sect2>
 
@@ -3043,92 +3292,123 @@ dmesg |grep SEV
   <sect1 xml:id="sec-virtualization-test-workload-npb">
     <title>Test VM workload: NPB</title>
 
-    <para>To match the experimental evaluation done on bare-metal, NPB base workloads have also been
+    <para>Trying to mach the experimental evaluation done on bare-metal, NPB base workloads have also been
       considered.</para>
 
     <sect2 xml:id="sec-virt-test-npb-onevm">
       <title>Test scenario: One large VM</title>
 
       <para><xref linkend="fig-nas-bm-1vm"/> shows the results of running the various NPB workloads
-        on the host in the default (BM default), tuned (BM tuned) and selective (BM selective)
-        configurations, compared with the exact same done inside one VM (VM default, VM tuned, VM
-        selective).</para>
+        on the host and in one VMs. In both cases, the tuning introduced above was applied (in the latter case, of course, inside of the VM itself).</para>
 
       <figure xml:id="fig-nas-bm-1vm">
-        <title>NAS Completion Time - Baremetal and in one VM with different configurations</title>
+        <title>NAS Completion Time - Baremetal and in one VM</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="nas-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-nas-bm-1vm.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="nas-bm-1vm.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-nas-bm-1vm.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <para> This makes pretty evident that, with proper tuning, also CPU bound workload running
-        inside a VM can achieve host-level performance. </para>
+      <para> Like for the STREAM case, a properly tuned VM can reach pretty much exactly the performance of the host. </para>
 
-      <para><xref linkend="fig-nas-selective-1vm-model"/> shows the impact of selecting a specific
-        CPU model for the VM (only the results for the selective configuration are reported). We see
-        that this aspect seems to play a smaller role for this benchmark, as compared to how it
-        changed the performance for STREAM. In any case, even for CPU bound workloads like NAS, the
-        EPYC model is the one to be preferred.</para>
+      <para><xref linkend="fig-nas-1vm-model"/> show again the impact on the performance of different CPU models.</para>
 
-      <figure xml:id="fig-nas-selective-1vm-model">
-        <title>NAS Completion Time - Selective configuration in one VM, varying the CPU
-          model</title>
+      <figure xml:id="fig-nas-1vm-model">
+        <title>STREAM Bandwidth - Single thread in one VM with different CPU models</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="nas-selective-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-nas-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="nas-selective-1vm-model.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC5-nas-1vm-model.svg" width="80%" format="SVG"/>
           </imageobject>
         </mediaobject>
       </figure>
+
+      <para> All the results are very similar and
+        the only benchmark(s) where the <parameter>cpupassthrough</parameter> model seems to have an edge is <parameter>cg.D</parameter> (and, but only slightly, <parameter>sp.D</parameter>).
+        Therefore, as already said for STREAM, considering that <parameter>cpumodel</parameter> runs show extremely good results, this guide recommends using it and
+        avoiding the potential issues coming from having an inaccurate topology and a misleading cache hierarchy representation inside of VMs. </para>
+
+    </sect2>
+
+    <sect2 xml:id="sec-virt-test-npb-multivm">
+      <title>Test scenario: Two to twelve VMs</title>
+
+      <para><xref linkend="fig-nas-bm-multivm"/> depicts the same as <xref linkend="fig-nas-bm-1vm"/>,
+        but for a few more cases, in terms of number of concurrently running VMs.
+      </para>
+
+      <figure xml:id="fig-nas-bm-multivm">
+        <title>NAS Completion Time - Baremetal and 1 to 16 VMs</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="EPYC5-nas-bm-16vm.svg" width="80%" format="PNG"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="EPYC5-nas-bm-16vm.svg" width="80%" format="PNG"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+
+      <para> We can see how the slowdown is linear (and sometimes even sub-linear) with the number of the VMs (the only exceptions being <parameter>lu.D</parameter>
+        with 16 VMs). And that makes sense considering that when we increase the number of VMs, each one of them can also
+        have fewer CPUs.
+        This testifies the effectivenes of the suggested tuning measures, when it comes
+        to guerantee a good level of isolation among multiple concurrently running VMs on the AMD EPYC 9005 Series Processors. </para>
 
     </sect2>
 
     <sect2 xml:id="sec-virt-test-npb-sev">
-      <title>Test scenario: Multiple VMs with Secure Encrypted Virtualization</title>
+      <title>Test scenario: Two VMs with Secure Encrypted Virtualization</title>
 
       <para>Similarly to what has been done with STREAM, we evaluate here the overhead introduced by
-        SEV for CPU on the NPB workloads and we do that while running it inside two (in <xref
-          linkend="fig-nas-tuned-2vms-sev"/>) and in four (<xref linkend="fig-nas-tuned-4vms-sev"/>)
-        VMs, with both SEV off and on.</para>
+        SEV and SEV-ES, this time for CPU-bound workloads, and we do that by running the NPB benchmarks it inside two VMs concurrently
+        that are all either unencrypted, encrypted with SEV or encrypted with SEV-ES (<xref linkend="fig-nas-tuned-2vms-sev"/>).</para>
 
       <figure xml:id="fig-nas-tuned-2vms-sev">
         <title>NAS Completion Time - Tuned configuration in 2 VM, with and without SEV</title>
         <mediaobject>
           <imageobject role="fo">
-            <imagedata fileref="nas-tuned-2vms-sev.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-2vms-sev.svg" width="80%" format="PNG"/>
           </imageobject>
           <imageobject role="html">
-            <imagedata fileref="nas-tuned-2vms-sev.png" width="80%" format="PNG"/>
+            <imagedata fileref="EPYC4-nas-2vms-sev.svg" width="80%" format="PNG"/>
           </imageobject>
         </mediaobject>
       </figure>
 
-      <figure xml:id="fig-nas-tuned-4vms-sev">
-        <title>NAS Completion Time - Tuned configuration in 4 VM, with and without SEV</title>
-        <mediaobject>
-          <imageobject role="fo">
-            <imagedata fileref="nas-tuned-4vms-sev.png" width="80%" format="PNG"/>
-          </imageobject>
-          <imageobject role="html">
-            <imagedata fileref="nas-tuned-4vms-sev.png" width="80%" format="PNG"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-
-      <para>Results are again pretty good, as the performance penalty because of SEV, on a CPU intensive
-        benchmark like NPB, is nearly non-existent (it is less than 0.5%).</para>
+      <para>As for the memory-intensive case the overhead introduced by either of the Confidential Computing
+        technologies is found to be really close to zero. In fact, it seems that --at least for the workloads analyzed in
+        this document-- AMD EPYC 9005 Series Processors can handle SEV and SEV-ES with even lower overhead than its predecessors.
+      </para>
 
     </sect2>
+  </sect1>
+
+  <sect1 xml:id="sec-conclusion">
+    <title>Conclusion</title>
+
+    <para>The introduction of the AMD EPYC 9005 Series Processors continues to push
+      the boundaries of what is possible for memory and
+      IO-bound workloads with significantly higher bandwidth and an increased number of channels. A
+      properly configured and tuned workload can exceed the performance of many contemporary
+      off-the-shelf solutions even when fully customized. The symmetric and balanced nature
+      of the machine makes the task of tuning a workload considerably easier, given that
+      each partition can have symmetric performance. And this is a property that can turn
+      out particularly handy in virtualization, as each virtual machine can be assigned
+      to each one of the partitions.</para>
+
+    <para>With SUSE Linux Enterprise 15 SP6, all the tools to monitor and tune a workload
+      are readily available. You can extract the maximum performance and
+      reliability running your applications on the 5th Generation AMD EPYC Processor
+      platform.</para>
 
   </sect1>
--->
 
   <sect1 xml:id="sec-resources">
     <title>Resources</title>
@@ -3185,7 +3465,6 @@ dmesg |grep SEV
 
   </sect1>-->
 
-<!-- Append A Virtualisation Specific
   <sect1 xml:id="sec-appendix-a">
     <title>Appendix A</title>
 
@@ -3194,7 +3473,6 @@ dmesg |grep SEV
     <screen>
 &lt;domain type="kvm">
   &lt;name>vm1&lt;/name>
-  &lt;uuid>e9afa48f-b359-4389-9ae6-5589240867c0&lt;/uuid>
   &lt;metadata>
     &lt;libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
       &lt;libosinfo:os id="http://suse.com/sle/15.2"/>
@@ -3567,7 +3845,6 @@ dmesg |grep SEV
     </screen>
 
   </sect1>
--->
 
   <?pdfpagebreak style="sbp" formatter="fop"?>
 


### PR DESCRIPTION
The tuning guide for the AMD EPYC 4 and 5 processors were published without the virtualization section. We agreed with AMD that we would have updated them and add such sections, which is exactly what this PR is doing.