### PR TITLE
Change EIC annotations

### DIFF
--- a/adoc/SAP-EIC-General.adoc
+++ b/adoc/SAP-EIC-General.adoc
@@ -8,13 +8,6 @@ https://help.sap.com/docs/integration-suite?locale=en-US and search for the "Edg
 
 
 
-# tag::disclaimer-annotation[]
-NOTE: In this guide, we use $ and # for shell commands, where # means that the command needs to be executed as a root user and
-$ means that the command can be run by any user.
-
-# end::disclaimer-annotation[]
-
-
 # tag::disclaimer-production-versions[]
 IMPORTANT: If you want to use different versions of {slem} or {slm}, {rancher}, {rke}, or {lh}, make sure to check the support matrix for the related solutions you want to use:
 https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/ +
@@ -36,7 +29,7 @@ The following excerpt provides an example of how to create a CA with a passphras
 
 [source, bash]
 ----
-$ openssl req -x509 -sha256 -days 1825 -newkey rsa:2048 -keyout rootCA.key -out rootCA.crt -passout pass:<ca-passphrase> -subj "/C=DE/ST=BW/L=Nuremberg/O=SUSE"
+openssl req -x509 -sha256 -days 1825 -newkey rsa:2048 -keyout rootCA.key -out rootCA.crt -passout pass:<ca-passphrase> -subj "/C=DE/ST=BW/L=Nuremberg/O=SUSE"
 ----
 
 This will generate the files _rootCA.key_ and _rootCA.crt_.
@@ -45,7 +38,7 @@ The following excerpt shows how to create such a CSR:
 
 [source, bash]
 ----
-$ openssl req -newkey rsa:2048 -keyout domain.key -out domain.csr -passout pass:<csr-passphrase> -subj  "/C=DE/ST=BW/L=Nuremberg/O=SUSE"
+openssl req -newkey rsa:2048 -keyout domain.key -out domain.csr -passout pass:<csr-passphrase> -subj  "/C=DE/ST=BW/L=Nuremberg/O=SUSE"
 ----
 
 Before you can sign the CSR, you need to add the DNS names of your Kuberntes Services to the CSR.
@@ -65,7 +58,7 @@ You can now use the previously created files _rootCA.key_ and _rootCA.crt_ with 
 The example below shows how to do that by passing the extension file (here called _domain.ext_):
 [source, bash]
 ----
-$ openssl x509 -req -CA rootCA.crt -CAkey rootCA.key -in domain.csr -out server.pem -days 365 -CAcreateserial -extfile domain.ext -passin pass:<ca-passphrase>
+openssl x509 -req -CA rootCA.crt -CAkey rootCA.key -in domain.csr -out server.pem -days 365 -CAcreateserial -extfile domain.ext -passin pass:<ca-passphrase>
 ----
 
 This creates a file called _server.pem_, which is the certificate to be used for your application.
@@ -75,7 +68,7 @@ Your _domain.key_ is still encrypted at this point, but the application requires
 To decrypt it, run the provided command, which will generate the _server.key_.
 [source, bash]
 ----
-$ openssl rsa -passin pass:<csr-passphrase> -in domain.key -out server.key
+openssl rsa -passin pass:<csr-passphrase> -in domain.key -out server.key
 ----
 
 Some applications (like Redis) require a full certificate chain to operate.
@@ -83,7 +76,7 @@ To get a full certificate chain, link the generated file _server.pem_ with the f
 
 [source, bash]
 ----
-$ cat server.pem rootCA.crt > chained.pem
+cat server.pem rootCA.crt > chained.pem
 ----
 
 # end::self-signed-certificates[]
@@ -96,7 +89,7 @@ For an example of uploading your certificates to Kubernetes, see the following e
 
 [source, bash]
 ----
-$ kubectl -n <namespace> create secret generic <certName> --from-file=./root.pem --from-file=./server.pem --from-file=./server.key
+kubectl -n <namespace> create secret generic <certName> --from-file=./root.pem --from-file=./server.pem --from-file=./server.key
 ----
 
 NOTE: All applications are expecting to have the secret to be used in the same namespace as the application.
@@ -174,10 +167,10 @@ spec:
 Apply the yaml file to your kubernetes cluster.
 [source, bash]
 ----
-$ kubectl apply -f selfsigned-issuer.yaml
-$ kubectl apply -f my-ca-cert.yaml
-$ kubectl apply -f my-ca-issuer.yaml
-$ kubectl apply -f application-name-certificate.yaml
+kubectl apply -f selfsigned-issuer.yaml
+kubectl apply -f my-ca-cert.yaml
+kubectl apply -f my-ca-issuer.yaml
+kubectl apply -f application-name-certificate.yaml
 ----
 
 When you deploy your applications via Helm Charts, you can use the generated certificate. 

--- a/adoc/SAP-EIC-Harvester-main.adoc
+++ b/adoc/SAP-EIC-Harvester-main.adoc
@@ -35,7 +35,7 @@ It will guide you through the steps of:
 * Deploying mandatory components for {eic}
 // * Deploying {eic} into your {rke}
 
-include::SAP-EIC-General.adoc[tags=disclaimer-EIC-sizing;disclaimer-annotation]
+include::SAP-EIC-General.adoc[tags=disclaimer-EIC-sizing]
 
 ++++
 <?pdfpagebreak?>

--- a/adoc/SAP-EIC-Harvester-main.adoc
+++ b/adoc/SAP-EIC-Harvester-main.adoc
@@ -110,6 +110,10 @@ While the VMs for the {rancher} cluster must be created directly in {harvester},
 The {eic} will need to run in a dedicated Kubernetes cluster.
 For an HA setup of this cluster, we recommend using three Kubernetes control planes and three Kubernetes worker nodes.
 
+++++
+<?pdfpagebreak?>
+++++
+
 For a graphical overview of what is needed, take a look at the landscape overview:
 
 image::SAP-EIC-Harvester-Architecture.svg[title=Architecture EIC Cluster,scaledwidth=99%,opts=inline,Embedded]
@@ -121,6 +125,7 @@ image::SAP-EIC-Harvester-Architecture.svg[title=Architecture EIC Cluster,scaledw
 
 We will use this graphic overview in the guide to illustrate what the next step is and what it is for.
 
+NOTE: If you want to test upgrades of {harvester}, we recommend setting up an additional {harvester} cluster and seperate the production {eic} instances from the development and test instances.
 
 Starting with installing {harvester}, we will walk you through all the steps you need to take to get a fully set-up Kubernetes landscape for deploying {eic}.
 

--- a/adoc/SAP-EIC-ImagePullSecrets.adoc
+++ b/adoc/SAP-EIC-ImagePullSecrets.adoc
@@ -15,8 +15,9 @@ Using `kubectl` to create the imagePullSecret is quite easy.
 Get your user name and your access token for the {rac}.
 Then run:
 
+[source, bash]
 ----
-$ kubectl -n <namespace> create secret docker-registry application-collection --docker-server=dp.apps.rancher.io --docker-username=<yourUser> --docker-password=<yourPassword>
+kubectl -n <namespace> create secret docker-registry application-collection --docker-server=dp.apps.rancher.io --docker-username=<yourUser> --docker-password=<yourPassword>
 ----
 
 As secrets are namespace-sensitive, you need to create this for every required namespace.

--- a/adoc/SAP-EIC-LoginRegistryApplicationCollection.adoc
+++ b/adoc/SAP-EIC-LoginRegistryApplicationCollection.adoc
@@ -10,7 +10,7 @@ This needs to be done with the Helm client.
 To log in to the {rac}, run:
 [source, bash]
 ----
-$ helm registry login dp.apps.rancher.io/charts -u <yourUser> -p <your-token>
+helm registry login dp.apps.rancher.io/charts -u <yourUser> -p <your-token>
 ----
 
 end::general-login[]

--- a/adoc/SAP-EIC-Main.adoc
+++ b/adoc/SAP-EIC-Main.adoc
@@ -20,6 +20,8 @@ It will guide you through the steps of:
 * Deploying mandatory components for {eic}
 // * Deploying {eic} into your {rke}
 
+include::SAP-EIC-General.adoc[tags=disclaimer-EIC-sizing]
+
 ++++
 <?pdfpagebreak?>
 ++++

--- a/adoc/SAP-EIC-Main.adoc
+++ b/adoc/SAP-EIC-Main.adoc
@@ -20,8 +20,6 @@ It will guide you through the steps of:
 * Deploying mandatory components for {eic}
 // * Deploying {eic} into your {rke}
 
-include::SAP-EIC-General.adoc[tags=disclaimer-EIC-sizing;disclaimer-annotation]
-
 ++++
 <?pdfpagebreak?>
 ++++
@@ -174,7 +172,7 @@ You must log in to {rac}. This can be done as follows:
 
 [source, bash]
 ----
-$ helm registry login dp.apps.rancher.io/charts -u <yourUser> -p <your-token>
+helm registry login dp.apps.rancher.io/charts -u <yourUser> -p <your-token>
 ----
 
 

--- a/adoc/SAP-EIC-Main.adoc
+++ b/adoc/SAP-EIC-Main.adoc
@@ -33,7 +33,7 @@ The support matrix below shows which versions of the given software we will use 
 |Product | Version
 
 |{slem} | {slem_version}
-|{rke} | 1.28     
+|{rke} | 1.31     
 |{rancher} | {rancher_version}
 |{lh} | {lh_version}
 |{cm} | {cm_version}

--- a/adoc/SAP-EIC-Metallb.adoc
+++ b/adoc/SAP-EIC-Metallb.adoc
@@ -16,8 +16,10 @@ Make sure to have one IP address available for configuring {metallb}.
 
 Before you can deploy {metallb} from {rac}, you need to create the namespace and an imagePullSecret.
 To create the related namespace, run:
+
+[source, bash]
 ----
-$ kubectl create namespace metallb
+kubectl create namespace metallb
 ----
 
 [#metalIPS]
@@ -41,7 +43,7 @@ imagePullSecrets:
 Then install the metallb application.
 [source, bash]
 ----
-$ helm install metallb oci://dp.apps.rancher.io/charts/metallb \
+helm install metallb oci://dp.apps.rancher.io/charts/metallb \
 -f values.yaml \
 --namespace=metallb \
 --version 0.14.7
@@ -58,7 +60,7 @@ $ helm install metallb oci://dp.apps.rancher.io/charts/metallb \
 Create the configuration files for the {metallb} IP address pool:
 [source,bash]
 ----
-$ cat <<EOF >iprange.yaml
+cat <<EOF >iprange.yaml
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -73,7 +75,7 @@ EOF
 Create the layer 2 network advertisement:
 [source,bash]
 ----
-$ cat <<EOF > l2advertisement.yaml
+cat <<EOF > l2advertisement.yaml
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
@@ -86,6 +88,6 @@ Apply the configuration:
 
 [source,bash]
 ----
-$ kubectl apply -f iprange.yaml
-$ kubectl apply -f l2advertisement.yaml
+kubectl apply -f iprange.yaml
+kubectl apply -f l2advertisement.yaml
 ----

--- a/adoc/SAP-EIC-PostgreSQL.adoc
+++ b/adoc/SAP-EIC-PostgreSQL.adoc
@@ -22,7 +22,7 @@ The {pg} chart can be found at https://apps.rancher.io/applications/postgresql.
 First, create a namespace and the *imagePullSecret* for installing the {pg} database onto the cluster.
 [source, bash, subs="attributes"]
 ----
-$ kubectl create namespace {pg_app_name}
+kubectl create namespace {pg_app_name}
 ----
 
 [#pgIPS]
@@ -89,7 +89,7 @@ podSecurityContext:
 To install the application, run:
 [source, bash, subs="attributes"]
 ----
-$ helm install {pg_app_name} oci://dp.apps.rancher.io/charts/{pg_app_name} -f values.yaml --namespace={pg_app_name}
+helm install {pg_app_name} oci://dp.apps.rancher.io/charts/{pg_app_name} -f values.yaml --namespace={pg_app_name}
 ----
 
 

--- a/adoc/SAP-EIC-Redis.adoc
+++ b/adoc/SAP-EIC-Redis.adoc
@@ -29,7 +29,7 @@ To create the namespace, run:
 
 [source, bash, subs="attributes"]
 ----
-$ kubectl create namespace {app_name}
+kubectl create namespace {app_name}
 ----
 
 [#redisIPS]
@@ -80,7 +80,7 @@ tls:
 To install the application, run:
 [source, bash, subs="attributes"]
 ----
-$ helm install {app_name} oci://dp.apps.rancher.io/charts/{app_name} \
+helm install {app_name} oci://dp.apps.rancher.io/charts/{app_name} \
 -f values.yaml \
 --namespace={app_name}
 ----

--- a/adoc/SAP-EIC-SLEMicro.adoc
+++ b/adoc/SAP-EIC-SLEMicro.adoc
@@ -28,11 +28,13 @@ For information that goes beyond the scope of this section, refer to the inline 
 To register {slem} with SUSE Customer Center, run `transactional-update register` as follows:
 [source, bash]
 ----
-$ transactional-update register -r REGISTRATION_CODE -e EMAIL_ADDRESS
+sudo transactional-update register -r REGISTRATION_CODE -e EMAIL_ADDRESS
 ----
 To register with a local registration server, additionally specify the URL to the server:
+
+[source, bash]
 ----
-$ transactional-update register -r REGISTRATION_CODE -e EMAIL_ADDRESS \
+sudo  transactional-update register -r REGISTRATION_CODE -e EMAIL_ADDRESS \
 --url "https://suse_register.example.com/"
 ----
 Do not forget to replace
@@ -47,8 +49,10 @@ Find more information about registering your system in the {slem} {slem_version}
 === Updating your system
 
 Log in to the system. After your system is registered, you can update it with the `transactional-update` command.
+
+[source, bash]
 ----
-$ transactional-update
+sudo transactional-update
 ----
 
 === Disabling automatic reboot
@@ -58,7 +62,7 @@ Disable it with the following command:
 
 [source, bash]
 ----
-$ systemctl --now disable transactional-update.timer
+sudo systemctl --now disable transactional-update.timer
 ----
 
 === Preparing for {lh}
@@ -69,20 +73,20 @@ The size of the second disk will depend on your use case.
 Install some packages as a requirement for {lh} and Logical Volume Management for adding a file system to {lh}.
 [source, bash]
 ----
-$ transactional-update pkg install lvm2 jq nfs-client cryptsetup open-iscsi
+sudo transactional-update pkg install lvm2 jq nfs-client cryptsetup open-iscsi
 ----
 
 After the required packages are installed, you need to reboot your machine. 
 [source, bash]
 ----
-$ reboot
+sudo reboot
 ----
 
 Now you can enable the `iscsid` server.
 
 [source, bash]
 ----
-$ systemctl enable iscsid  --now
+sudo systemctl enable iscsid  --now
 ----
 
 ==== Creating file system for {lh}
@@ -92,42 +96,42 @@ The next step is to create a new logical volume with the Logical Volume Manageme
 First, you need to create a new physical volume. In our case, the second disk is called _vdb_. Use this as {lh} volume.
 [source, bash]
 ----
-$ pvcreate /dev/vdb
+sudo pvcreate /dev/vdb
 ----
 
 After the physical volume is created, create a volume group called _vgdata_:
 [source, bash]
 ----
-$ vgcreate vgdata /dev/vdb
+sudo vgcreate vgdata /dev/vdb
 ----
 
 Now create the logical volume; use 100% of the disk. 
 [source, bash]
 ----
-$ lvcreate -n lvlonghorn -l100%FREE vgdata
+sudo lvcreate -n lvlonghorn -l100%FREE vgdata
 ----
 
 On the logical volume, create the XFS file system. You do not need to create a partion on top of it.
 [source, bash]
 ----
-$ mkfs.xfs /dev/vgdata/lvlonghorn
+sudo mkfs.xfs /dev/vgdata/lvlonghorn
 ----
 
 Before you can mount the device, you need to create the directory structure.
 [source, bash]
 ----
-$ mkdir -p /var/lib/longhorn
+sudo mkdir -p /var/lib/longhorn
 ----
 
 Add an entry to _fstab_ to ensure that the mount of the file system is persistent:
 [source, bash]
 ----
-$ echo -e "/dev/vgdata/lvlonghorn /var/lib/longhorn xfs defaults 0 0" >> /etc/fstab
+sudo echo -e "/dev/vgdata/lvlonghorn /var/lib/longhorn xfs defaults 0 0" >> /etc/fstab
 ----
 
 Finally, you can mount the file system as follows:
 [source, bash]
 ----
-$ mount -a
+sudo mount -a
 ----
 

--- a/adoc/SAP-EIC-Variables.adoc
+++ b/adoc/SAP-EIC-Variables.adoc
@@ -2,15 +2,15 @@
 :sles4sap: SUSE Linux Enterprise Server for SAP applications
 :slm: SUSE Linux Micro
 :slem: SUSE Linux Enterprise Micro
-:slem_version: 5.4
+:slem_version: 6.0
 :sles_version: 15 SP5
 
 
 :sle_ha: SUSE Linux Enterprise High Availability
 :lh: Longhorn
-:lh_version: 1.5.5
+:lh_version: 1.7.2
 :rancher: SUSE Rancher Prime
-:rancher_version: 2.8.3
+:rancher_version: 2.10.1
 :rancher4SAP: Rancher for SAP applications
 :rke: Rancher Kubernetes Engine 2
 :rac: Rancher Application Collection

--- a/adoc/SAP-K8s-HA.adoc
+++ b/adoc/SAP-K8s-HA.adoc
@@ -18,7 +18,7 @@ Install the `haproxy` package.
 
 [source, bash]
 ----
-$ zypper in haproxy
+sudo zypper in haproxy
 ----
 
 Create the configuration for `haproxy`.
@@ -27,7 +27,7 @@ Find an example configuration file for `haproxy` below and adapt for the actual 
 ifdef::eic[]
 [source, bash]
 ----
-# cat <<EOF > /etc/haproxy/haproxy.cfg 
+sudo cat <<EOF > /etc/haproxy/haproxy.cfg 
 global
         log /dev/log    local0
         log /dev/log    local1 notice
@@ -111,7 +111,7 @@ endif::[]
 ifndef::eic[]
 [source, bash]
 ----
-# cat <<EOF > /etc/haproxy/haproxy.cfg 
+sudo cat <<EOF > /etc/haproxy/haproxy.cfg 
 global
   log /dev/log daemon
   maxconn 32768
@@ -176,13 +176,14 @@ endif::[]
 Check the configuration file:
 [source, bash]
 ----
-$ haproxy -f /path/to/your/haproxy.conf -c
+haproxy -f /path/to/your/haproxy.conf -c
 ----
 
 Enable and start the `haproxy` load balancer:
+[source, bash]
 ----
-$ systemctl enable haproxy
-$ systemctl start haproxy
+sudo systemctl enable haproxy
+sudo systemctl start haproxy
 ----
 
 Do not forget to restart or reload `haproxy` if any changes are made to the haproxy configuration file.

--- a/adoc/SAPDI3-Install.adoc
+++ b/adoc/SAPDI3-Install.adoc
@@ -20,9 +20,10 @@ The following steps need to be executed before the deployment of {di} {di_versio
 
 Log in to your management workstation and create the namespace in the Kubernetes cluster where DI {di_version} will be deployed.
 
+[source, bash]
 ----
-$ kubectl create ns <NAMESPACE for DI 31>
-$ kubectl get ns
+kubectl create ns <NAMESPACE for DI 31>
+kubectl get ns
 ----
 
 ==== Creating _cert_ file to access the secure private registry
@@ -30,9 +31,10 @@ $ kubectl get ns
 Create a file named _cert_ that contains the SSL certificate chain for the secure private registry.
 This imports the certificates into {di} {di_version}. 
 //TODO Uli check completeness of commands below
+[source, bash]
 ----
-$ cat CA.pem > cert
-$ kubectl -n <NAMESPACE for DI 31> create secret generic cmcertificates --from-file=cert
+cat CA.pem > cert
+kubectl -n <NAMESPACE for DI 31> create secret generic cmcertificates --from-file=cert
 ----
 
 === Creating default storage class
@@ -44,8 +46,9 @@ Below find an example for a `ceph`/`rbd` based storage class that uses the CSI.
 
 * Create `config-map`:
 +
+[source, bash]
 ----
-$ cat << EOF > csi-config-map.yaml
+cat << EOF > csi-config-map.yaml
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -68,8 +71,9 @@ EOF
 
 * Create a secret to access the storage:
 +
+[source, bash]
 ----
-$ cat << EOF > csi-rbd-secret.yaml
+cat << EOF > csi-rbd-secret.yaml
 ---
 apiVersion: v1
 kind: Secret
@@ -84,20 +88,23 @@ EOF
 
 * Download the file:
 +
+[source, bash]
 ----
-$ curl -LO https://raw.githubusercontent.com/ceph/ceph-csi/master/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+curl -LO https://raw.githubusercontent.com/ceph/ceph-csi/master/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
 ----
 
 * Download the file:
 +
+[source, bash]
 ----
-$ curl -LO https://raw.githubusercontent.com/ceph/ceph-csi/master/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+curl -LO https://raw.githubusercontent.com/ceph/ceph-csi/master/deploy/rbd/kubernetes/csi-rbdplugin.yaml
 ----
 
 * Create a pool on the Ceph storage where the PVs will be created, and insert the pool name and the Ceph cluster ID:
 +
+[source, bash]
 ----
-$ cat << EOF > csi-rbd-sc.yaml
+cat << EOF > csi-rbd-sc.yaml
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -119,8 +126,9 @@ EOF
 
 * Create _config_ for encryption. This is needed, else the deployment of the CSI driver for `ceph`/`rbd` will fail.
 +
+[source, bash]
 ----
-$ cat << EOF > kms-config.yaml
+cat << EOF > kms-config.yaml
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -154,25 +162,30 @@ EOF
 
 * Deploy the `ceph`/`rbd` CSI and storage class: 
 +
+[source, bash]
 ----
-$ kubectl apply -f csi-config-map.yaml
-$ kubectl apply -f csi-rbd-secret.yaml
-$ kubectl apply -f \ 
+kubectl apply -f csi-config-map.yaml
+kubectl apply -f csi-rbd-secret.yaml
+kubectl apply -f \ 
   https://raw.githubusercontent.com/ceph/ceph-csi/master/deploy/rbd/kubernetes/csi-provisioner-rbac.yaml
-$ kubectl apply -f \
+kubectl apply -f \
   https://raw.githubusercontent.com/ceph/ceph-csi/master/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
-$ kubectl apply -f csi-rbdplugin-provisioner.yaml 
-$ kubectl apply -f csi-rbdplugin.yaml 
-$ kubectl apply -f csi-rbd-sc.yaml 
-$ kubectl apply -f kms-config.yaml
-$ kubectl patch storageclass csi-rbd-sc \
+kubectl apply -f csi-rbdplugin-provisioner.yaml 
+kubectl apply -f csi-rbdplugin.yaml 
+kubectl apply -f csi-rbd-sc.yaml 
+kubectl apply -f kms-config.yaml
+kubectl patch storageclass csi-rbd-sc \
   -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ----
 
 * Check your storage class:
 +
+[source, bash]
 ----
-$ kubectl get sc
+kubectl get sc
+----
++
+----
 NAME                   PROVISIONER        RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-rbd-sc (default)   rbd.csi.ceph.com   Delete          Immediate           false                  103m
 ----
@@ -195,11 +208,12 @@ Download the SLC Bridge software to the management workstation.
 
 Rename the SLC Bridge binary to `slcb` and make it executable. Deploy the SLC Bridge to the Kubernetes cluster.
 
+[source, bash]
 ----
-$ mv SLCB01_XX-70003322.EXE slcb
-$ chmod 0700 slcb
-$ export KUBECONFIG=<KUBE_CONFIG>
-$ ./slcb init
+mv SLCB01_XX-70003322.EXE slcb
+chmod 0700 slcb
+export KUBECONFIG=<KUBE_CONFIG>
+./slcb init
 ----
 
 During the interactive installation, the following information is needed:
@@ -211,8 +225,9 @@ During the interactive installation, the following information is needed:
 Take a note of the service port of the SLC Bridge. It is needed for the installation of {di} {di_version} or for the reconfiguration of DI {di_version}, 
 for example to enable backup. If you forgot to note it down, the following command will list the service port:
 // FIXME add screenshot / command line showing result service port > 30000
+[source, bash]
 ----
-$ kubectl -n sap-slcbridge get svc
+kubectl -n sap-slcbridge get svc
 ----
 
 === Creating and downloading Stack XML for the {di} installation
@@ -233,9 +248,10 @@ Download the Stack XML file to a local directory. Copy _stack.xml_ to the manage
 
 The installation of {di} {di_version} is invoked by:
 
+[source, bash]
 ----
-$ export KUBECONFIG=<path to kubeconfig>
-$ ./slcb execute --useStackXML MP_Stack_XXXXXXXXXX_XXXXXXXX_.xml --url https://<node>:<service port>/docs/index.html
+export KUBECONFIG=<path to kubeconfig>
+./slcb execute --useStackXML MP_Stack_XXXXXXXXXX_XXXXXXXX_.xml --url https://<node>:<service port>/docs/index.html
 ----
 
 This starts an interactive process for configuring and deploying {di} {di_version}.
@@ -275,14 +291,16 @@ After the installation workflow is successfully finished, you need to carry out 
 
 ** Create a certificate request using `openssl`, for example:
 +
+[source, bash]
 ----
-$ openssl req -newkey rsa:2048 -keyout <hostname>.key -out <hostname>.csr
+openssl req -newkey rsa:2048 -keyout <hostname>.key -out <hostname>.csr
 ----
 
 ** Decrypt the key: 
 +
+[source, bash]
 ----
-$ openssl rsa -in <hostname>.key -out decrypted-<hostname>.key
+openssl rsa -in <hostname>.key -out decrypted-<hostname>.key
 ----
 
 ** Let a CA sign the <hostname>.csr
@@ -290,9 +308,10 @@ You will receive  a <hostname>.crt.
 
 ** Create a secret from the certificate and the key in the {di} 3 namespace:
 +
+[source, bash]
 ----
-$ export NAMESPACE=<{di} 3 namespace>
-$ kubectl -n $NAMESPACE create secret tls vsystem-tls-certs --key  decrypted-<hostname>.key--cert <hostname>.crt
+export NAMESPACE=<{di} 3 namespace>
+kubectl -n $NAMESPACE create secret tls vsystem-tls-certs --key  decrypted-<hostname>.key--cert <hostname>.crt
 ----
 
 * Deploy an `nginx-ingress` controller:
@@ -301,20 +320,21 @@ $ kubectl -n $NAMESPACE create secret tls vsystem-tls-certs --key  decrypted-<ho
 
 ** Create the `nginx-ingress` controller as a *nodePort* service according to the Ingress `nginx` documentation:
 +
+[source, bash]
 ----
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.46.0/deploy/static/provider/baremetal/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.46.0/deploy/static/provider/baremetal/deploy.yaml
 ----
 
 ** Determine the port the `nginx` controller is redirecting HTTPS to:
 +
+[source, bash]
 ----
-$ kubectl -n ingress-nginx get svc ingress-nginx-controller
+kubectl -n ingress-nginx get svc ingress-nginx-controller
 ----
 +
 The output should be similar to the below:
 +
 ----
-kubectl -n ingress-nginx get svc ingress-nginx-controller
 NAME                       TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)                      AGE
 ingress-nginx-controller   NodePort   10.43.86.90   <none>        80:31963/TCP,443:{di_version}06/TCP   53d
 ----
@@ -323,8 +343,9 @@ In our example here, the TLS port is be {di_version}06. Note the port IP down as
 
 * Create an Ingress to access the {di} installation:
 +
+[source, bash]
 ----
-$ cat <<EOF > ingress.yaml
+cat <<EOF > ingress.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -353,7 +374,7 @@ spec:
     - "<hostname FQDN must match SSL certificate>"
     secretName: vsystem-tls-certs
 EOF
-$ kubectl apply -f ingress.yaml
+kubectl apply -f ingress.yaml
 ----
 
 * Connecting to \https://hostname:<ingress service port> brings up the {di} login dialog. 
@@ -404,10 +425,11 @@ the installation must be registered either to SUSE Customer Center, an SMT or RM
 
 * {sles} {sles_version} can be updated on the command line using `zypper`:
 +
+[source, bash]
 ----
-$ sudo zypper ref -s
-$ sudo zypper lu
-$ sudo zypper patch
+sudo zypper ref -s
+sudo zypper lu
+sudo zypper patch
 ----
 
 * Other methods for updating {sles} {sles_version} are described in the https://documentation.suse.com/sles[product documentation].
@@ -416,55 +438,62 @@ If an update requires a reboot of the server, make sure that this can be done sa
 
 * For example, block access to {di}, and drain and cordon the Kubernetes node before rebooting:
 +
+[source, bash]
 ----
-$ kubectl edit ingress <put in some dummy port>
-$ kubectl drain <node>
+kubectl edit ingress <put in some dummy port>
+kubectl drain <node>
 ----
 
 * Check the status of the node:
 +
 ----
-$kubectl get node <node>
+kubectl get node <node>
 ----
 +
 The node should be marked as *not schedulable*.
 
 * On RKE 2 master nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl stop rke2-server
+sudo systemctl stop rke2-server
 ----
 
 * On RKE 2 worker nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl stop rke2-agent
+sudo systemctl stop rke2-agent
 ----
 
 * Update {sles} {sles_version}:
 +
+[source, bash]
 ----
-$ ssh node
-$ sudo zypper patch
+ssh node
+sudo zypper patch
 ----
 
 * Reboot the nodes if necessary or start the appropriate RKE 2 service.
 
 ** On master nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl start rke2-server
+sudo systemctl start rke2-server
 ----
 
 ** On worker nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl start rke2-agent
+sudo systemctl start rke2-agent
 ----
  
 * Check if the respective nodes are back and uncordon them.
 +
+[source, bash]
 ----
-$ kubectl get nodes
-$ kubectl uncordon <node>
+kubectl get nodes
+kubectl uncordon <node>
 ----

--- a/adoc/SAPDI3-Longhorn.adoc
+++ b/adoc/SAPDI3-Longhorn.adoc
@@ -14,14 +14,14 @@ all nodes must have the `open-iscsi` package installed, and the ISCSI daemon nee
 
 [source, bash]
 ----
-# zypper in -y open-iscsi
-# systemctl enable iscsid  --now
+sudo zypper in -y open-iscsi
+sudo systemctl enable iscsid  --now
 ----
 endif::[]
 
 To ensure a node is prepared for {lh}, you can use the following script to check:
 ----
-$ curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v1.6.2/scripts/environment_check.sh | bash
+curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v1.6.2/scripts/environment_check.sh | bash
 ----
 
 
@@ -37,12 +37,12 @@ ifdef::eic[]
 To install Longhorn using Helm, run the following commands:
 [source, bash]
 ----
-$ helm repo add rancher-v2.8-charts https://raw.githubusercontent.com/rancher/charts/release-v2.8
-$ helm repo update
-$ helm upgrade --install longhorn-crd rancher-v2.8-charts/longhorn-crd \
+helm repo add rancher-v2.8-charts https://raw.githubusercontent.com/rancher/charts/release-v2.8
+helm repo update
+helm upgrade --install longhorn-crd rancher-v2.8-charts/longhorn-crd \
 --namespace longhorn-system \
 --create-namespace
-$ helm upgrade --install longhorn rancher-v2.8-charts/longhorn \
+helm upgrade --install longhorn rancher-v2.8-charts/longhorn \
 --namespace longhorn-system
 ----
 endif::[]
@@ -50,9 +50,9 @@ ifndef::eic[]
 To install Longhorn using Helm, run the following commands:
 [source, bash]
 ----
-$ helm repo add longhorn https://charts.longhorn.io
-$ helm repo update
-$ helm install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace
+helm repo add longhorn https://charts.longhorn.io
+helm repo update
+helm install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace
 ----
 
 These commands will add the Longhorn Helm charts to the list of Helm repositories, update the Helm repository, and execute the installation of Longhorn.
@@ -65,7 +65,7 @@ You can install {lh} using `kubectl` with the following command:
 [subs="attributes"]
 [source, bash]
 ----
-$ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{lh_version}/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{lh_version}/deploy/longhorn.yaml
 ----
 
 
@@ -76,7 +76,7 @@ $ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{lh_vers
 +
 [source, bash]
 ----
-$ USER=<USERNAME_HERE>; \
+USER=<USERNAME_HERE>; \
   PASSWORD=<PASSWORD_HERE>; \
   echo "${USER}:$(openssl passwd -stdin -apr1 <<< ${PASSWORD})" >> auth
 ----
@@ -85,14 +85,14 @@ $ USER=<USERNAME_HERE>; \
 +
 [source, bash]
 ----
-$ kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
+kubectl -n longhorn-system create secret generic basic-auth --from-file=auth
 ----
 
 * Create the Ingress with basic authentication:
 +
 [source, bash]
 ----
-$ cat <<EOF > longhorn-ingress.yaml
+cat <<EOF > longhorn-ingress.yaml
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -117,7 +117,7 @@ spec:
           servicePort: 80
 EOF
 
-$ kubectl -n longhorn-system apply -f longhorn-ingress.yaml
+kubectl -n longhorn-system apply -f longhorn-ingress.yaml
 ----
 endif::[]
 

--- a/adoc/SAPDI3-Rancher.adoc
+++ b/adoc/SAPDI3-Rancher.adoc
@@ -7,15 +7,15 @@
 To install RKE2, the script provided at https://get.rke2.io can be used as follows:
 [source, bash]
 ----
-$ curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.31.7+rke2r1 sh
+sudo curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=v1.31.7+rke2r1 sh
 ----
 
 For HA setups, you must create RKE2 cluster configuration files in advance.
 On the first master node, do the following:
 [source, bash]
 ----
-$ mkdir -p /etc/rancher/rke2
-$ cat <<EOF > /etc/rancher/rke2/config.yaml
+sudo mkdir -p /etc/rancher/rke2
+cat <<EOF > /etc/rancher/rke2/config.yaml
 token: 'your cluster token'
 system-default-registry: registry.rancher.com
 tls-san:
@@ -29,7 +29,7 @@ EOF
 Create configuration files for additional cluster nodes:
 [source, bash]
 ----
-$ cat <<EOF > /etc/rancher/rke2/config.yaml
+cat <<EOF > /etc/rancher/rke2/config.yaml
 server: https://"FQDN of registration address":9345
 token: 'your cluster token'
 system-default-registry: registry.rancher.com
@@ -47,15 +47,17 @@ IMPORTANT: For security reasons, we generally recommend activating the CIS profi
 This is currently still being validated and will be included in the documentation at a later date. 
 
 Now enable and start the RKE2 components and run the following command on each cluster node:
+
+[source, bash]
 ----
-$ systemctl enable rke2-server --now
+sudo systemctl enable rke2-server --now
 ----
 
 To verify the installation, run the following command:
 
 [source, bash]
 ----
-$ /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes
+/var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml get nodes
 ----
 
 For convenience, you can add the `kubectl` binary to the *$PATH* and set the specified `kubeconfig` 
@@ -63,8 +65,8 @@ via an environment variable:
 
 [source, bash]
 ----
-$ export PATH=$PATH:/var/lib/rancher/rke2/bin/
-$ export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+export PATH=$PATH:/var/lib/rancher/rke2/bin/
+export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
 ----
 
 
@@ -79,7 +81,7 @@ To install {rancher} and some of its required components, you need to use Helm.
 One way to install Helm is to run:
 [source, bash]
 ----
-$ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 ----
 
 # end::helm-install[]
@@ -89,8 +91,10 @@ $ curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bas
 === Installing cert-manager
 
 To install the `cert-manager` package, do the following:
+
+[source, bash]
 ----
-$ kubectl create namespace cert-manager
+kubectl create namespace cert-manager
 ----
 
 # end::cert-manager-install[]
@@ -117,13 +121,13 @@ You will need to login to the {rac}:
 
 [source, bash]
 ----
-$ helm registry login dp.apps.rancher.io/charts -u <yourUser> -p <your-token>
+helm registry login dp.apps.rancher.io/charts -u <yourUser> -p <your-token>
 ----
 endif::[]
 
 [source, bash]
 ----
-$ helm install cert-manager oci://dp.apps.rancher.io/charts/cert-manager \
+helm install cert-manager oci://dp.apps.rancher.io/charts/cert-manager \
     --set crds.enabled=true \
     --set-json 'global.imagePullSecrets=[{"name":"application-collection"}]' \
     --namespace=cert-manager \
@@ -137,19 +141,20 @@ To achieve that, use the following command:
 
 [source, bash]
 ----
-$ helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
+helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
 ----
 
 Next, create the `cattle-system` namespace in Kubernetes as follows:
+[source, bash]
 ----
-$ kubectl create namespace cattle-system
+kubectl create namespace cattle-system
 ----
 
 The Kubernetes cluster is now ready for the installation of {rancher}:
 
 [source, bash]
 ----
-$ helm install rancher rancher-prime/rancher \
+helm install rancher rancher-prime/rancher \
     --namespace cattle-system \
     --set hostname=<your.domain.com> \
     --set replicas=3
@@ -159,7 +164,7 @@ During the rollout of {rancher}, you can monitor the progress using the followin
 
 [source, bash]
 ----
-$ kubectl -n cattle-system rollout status deploy/rancher
+kubectl -n cattle-system rollout status deploy/rancher
 ----
 
 When the deployment is done, you can access the {rancher} cluster at https://<your.domain.com>[]. 

--- a/adoc/SAPDI3-SUSE-VMWare-VSAN-Install.adoc
+++ b/adoc/SAPDI3-SUSE-VMWare-VSAN-Install.adoc
@@ -142,14 +142,14 @@ After the installation workflow is successfully finished, you need to carry out 
 +
 [source, bash]
 ----
-$ openssl req -newkey rsa:2048 -keyout <hostname>.key -out <hostname>.csr
+openssl req -newkey rsa:2048 -keyout <hostname>.key -out <hostname>.csr
 ----
 
 ** Decrypt the key: 
 +
 [source, bash]
 ----
-$ openssl rsa -in <hostname>.key -out decrypted-<hostname>.key
+openssl rsa -in <hostname>.key -out decrypted-<hostname>.key
 ----
 
 ** Let a CA sign the <hostname>.csr

--- a/adoc/SAPDI3-SUSE-VMWare-VSAN-Install.adoc
+++ b/adoc/SAPDI3-SUSE-VMWare-VSAN-Install.adoc
@@ -19,9 +19,10 @@ The following steps need to be executed before the deployment of {di} {di_versio
 
 Log in to your management workstation and create the namespace in the Kubernetes cluster where DI {di_version} will be deployed.
 
+[source, bash]
 ----
-$ kubectl create ns <NAMESPACE for DI 31>
-$ kubectl get ns
+kubectl create ns <NAMESPACE for DI 31>
+kubectl get ns
 ----
 
 ==== Creating _cert_ file to access the secure private registry
@@ -29,10 +30,12 @@ $ kubectl get ns
 Create a file named _cert_ that contains the SSL certificate chain for the secure private registry.
 This imports the certificates into {di} {di_version}. Make sure that the file does not contain DOS-type line endings. The commands listed below will remove the DOS-type line endings and create the necessary secret.
 //TODO Uli check completeness of commands below
+
+[source, bash]
 ----
-$ cat CA.pem > cert_with_cr
-$ tr -d '\r' < cert_with_cr > cert
-$ kubectl -n <NAMESPACE for DI 3> create secret generic cmcertificates --from-file=cert
+cat CA.pem > cert_with_cr
+tr -d '\r' < cert_with_cr > cert
+kubectl -n <NAMESPACE for DI 3> create secret generic cmcertificates --from-file=cert
 ----
 
 
@@ -54,11 +57,12 @@ Download the SLC Bridge software to the management workstation.
 
 Rename the SLC Bridge binary to `slcb` and make it executable. Deploy the SLC Bridge to the Kubernetes cluster.
 
+[source, bash]
 ----
-$ mv SLCB01_XX-70003322.EXE slcb
-$ chmod 0700 slcb
-$ export KUBECONFIG=<KUBE_CONFIG>
-$ ./slcb init
+mv SLCB01_XX-70003322.EXE slcb
+chmod 0700 slcb
+export KUBECONFIG=<KUBE_CONFIG>
+./slcb init
 ----
 
 During the interactive installation, the following information is needed:
@@ -70,8 +74,9 @@ During the interactive installation, the following information is needed:
 Take a note of the service port of the SLC Bridge. It is needed for the installation of {di} {di_version} or for the reconfiguration of DI {di_version}, 
 for example to enable backup. If you forgot to note it down, the following command will list the service port:
 // FIXME add screenshot / command line showing result service port > 30000
+[source, bash]
 ----
-$ kubectl -n sap-slcbridge get svc
+kubectl -n sap-slcbridge get svc
 ----
 
 === Creating and downloading Stack XML for the {di} installation
@@ -92,9 +97,10 @@ Download the Stack XML file to a local directory. Copy _stack.xml_ to the manage
 
 The installation of {di} {di_version} is invoked by:
 
+[source, bash]
 ----
-$ export KUBECONFIG=<path to kubeconfig>
-$ ./slcb execute --useStackXML MP_Stack_XXXXXXXXXX_XXXXXXXX_.xml --url https://<node>:<service port>/docs/index.html
+export KUBECONFIG=<path to kubeconfig>
+./slcb execute --useStackXML MP_Stack_XXXXXXXXXX_XXXXXXXX_.xml --url https://<node>:<service port>/docs/index.html
 ----
 
 This starts an interactive process for configuring and deploying {di} {di_version}.
@@ -134,12 +140,14 @@ After the installation workflow is successfully finished, you need to carry out 
 
 ** Create a certificate request using `openssl`, for example:
 +
+[source, bash]
 ----
 $ openssl req -newkey rsa:2048 -keyout <hostname>.key -out <hostname>.csr
 ----
 
 ** Decrypt the key: 
 +
+[source, bash]
 ----
 $ openssl rsa -in <hostname>.key -out decrypted-<hostname>.key
 ----
@@ -149,9 +157,10 @@ You will receive  a <hostname>.crt.
 
 ** Create a secret from the certificate and the key in the {di} 3 namespace:
 +
+[source, bash]
 ----
-$ export NAMESPACE=<{di} 3 namespace>
-$ kubectl -n $NAMESPACE create secret tls vsystem-tls-certs --key  decrypted-<hostname>.key--cert <hostname>.crt
+export NAMESPACE=<{di} 3 namespace>
+kubectl -n $NAMESPACE create secret tls vsystem-tls-certs --key  decrypted-<hostname>.key--cert <hostname>.crt
 ----
 
 * Deploy an `nginx-ingress` controller:
@@ -160,20 +169,26 @@ $ kubectl -n $NAMESPACE create secret tls vsystem-tls-certs --key  decrypted-<ho
 
 ** Create the `nginx-ingress` controller as a *nodePort* service according to the Ingress `nginx` documentation:
 +
+[source, bash]
 ----
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.46.0/deploy/static/provider/baremetal/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.46.0/deploy/static/provider/baremetal/deploy.yaml
 ----
 
 ** Determine the port the `nginx` controller is redirecting HTTPS to:
 +
+[source, bash]
 ----
-$ kubectl -n ingress-nginx get svc ingress-nginx-controller
+kubectl -n ingress-nginx get svc ingress-nginx-controller
 ----
 +
 The output should be similar to the below:
 +
+[source, bash]
 ----
 kubectl -n ingress-nginx get svc ingress-nginx-controller
+----
+
+----
 NAME                       TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)                      AGE
 ingress-nginx-controller   NodePort   10.43.86.90   <none>        80:31963/TCP,443:{di_version}06/TCP   53d
 ----
@@ -182,8 +197,9 @@ In our example here, the TLS port is be {di_version}06. Note the port IP down as
 
 * Create an Ingress to access the {di} installation:
 +
+[source, bash]
 ----
-$ cat <<EOF > ingress.yaml
+cat <<EOF > ingress.yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -212,7 +228,7 @@ spec:
     - "<hostname FQDN must match SSL certificate>"
     secretName: vsystem-tls-certs
 EOF
-$ kubectl apply -f ingress.yaml
+kubectl apply -f ingress.yaml
 ----
 
 * Connecting to \https://hostname:<ingress service port> brings up the {di} login dialog. 
@@ -263,10 +279,11 @@ the installation must be registered either to SUSE Customer Center, an SMT or RM
 
 * {sles} {sles_version} can be updated on the command line using `zypper`:
 +
+[source, bash]
 ----
-$ sudo zypper ref -s
-$ sudo zypper lu
-$ sudo zypper patch
+sudo zypper ref -s
+sudo zypper lu
+sudo zypper patch
 ----
 
 * Other methods for updating {sles} {sles_version} are described in the https://documentation.suse.com/sles[product documentation].
@@ -275,55 +292,63 @@ If an update requires a reboot of the server, make sure that this can be done sa
 
 * For example, block access to {di}, and drain and cordon the Kubernetes node before rebooting:
 +
+[source, bash]
 ----
-$ kubectl edit ingress <put in some dummy port>
-$ kubectl drain <node>
+kubectl edit ingress <put in some dummy port>
+kubectl drain <node>
 ----
 
 * Check the status of the node:
 +
+[source, bash]
 ----
-$kubectl get node <node>
+kubectl get node <node>
 ----
 +
 The node should be marked as *not schedulable*.
 
 * On RKE 2 master nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl stop rke2-server
+sudo systemctl stop rke2-server
 ----
 
 * On RKE 2 worker nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl stop rke2-agent
+sudo systemctl stop rke2-agent
 ----
 
 * Update {sles} {sles_version}:
 +
+[source, bash]
 ----
-$ ssh node
-$ sudo zypper patch
+ssh node
+sudo zypper patch
 ----
 
 * Reboot the nodes if necessary or start the appropriate RKE 2 service.
 
 ** On master nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl start rke2-server
+sudo systemctl start rke2-server
 ----
 
 ** On worker nodes, run the command:
 +
+[source, bash]
 ----
-$ sudo systemctl start rke2-agent
+sudo systemctl start rke2-agent
 ----
  
 * Check if the respective nodes are back and uncordon them.
 +
+[source, bash]
 ----
-$ kubectl get nodes
-$ kubectl uncordon <node>
+kubectl get nodes
+kubectl uncordon <node>
 ----

--- a/adoc/SAPDI3-Vsphere-Vsan.adoc
+++ b/adoc/SAPDI3-Vsphere-Vsan.adoc
@@ -32,9 +32,10 @@ These data will be used to configure the helm manifests for the vsphere CPI and 
 
 To use the vSphere CPI and CSI, RKE2 must be configured to use the rancher-vsphere cloud provider.
 
+[source, bash, subs="attributes"]
 ----
-$ sudo  mkdir -p /etc/rancher/rke2
-$ sudo echo "cloud-provider-name: rancher-vsphere" > /etc/rancher/rke2/config.yaml"
+sudo mkdir -p /etc/rancher/rke2
+sudo echo "cloud-provider-name: rancher-vsphere" > /etc/rancher/rke2/config.yaml"
 ----
 
 This enables the deployment of the vSphere CPI and CSI from pre-packaged Helm charts in RKE 2.
@@ -44,20 +45,23 @@ Create the configuration for the CPI vSphere provider Helm chart:
 
 * Create the directory structure on first the master node 
 
+[source, bash]
 ----
-$ sudo mkdir -p /var/lib/rancher/rke2/server/manifests
-$ cd /var/lib/rancher/rke2/server/manifests
+sudo mkdir -p /var/lib/rancher/rke2/server/manifests
+sudo cd /var/lib/rancher/rke2/server/manifests
 ----
 
 
 Then create the file `rancher-vsphere-cpi-config.yaml` in the directory. 
 
+[source, shell]
 ----
 /var/lib/rancher/rke2/server/manifests
 ---- 
 
+[source, bash]
 ----
-$ cat <<EOF >
+cat <<EOF >
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
@@ -83,8 +87,9 @@ EOF
 
 In the same directory, the file `rancher-vsphere-csi-config.yaml` will be created.
 
+[source, bash]
 ----
-$ cat <<EOF > /var/lib/rancher/rke2/server/manifests/rancher-vsphere-csi-config.yaml
+cat <<EOF > /var/lib/rancher/rke2/server/manifests/rancher-vsphere-csi-config.yaml
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
@@ -130,20 +135,22 @@ Now you can deploy the RKE 2 cluster on the dedicated virtual machines.
 
 * Download and install RKE 2
 
+[source, bash]
 ----
-$ export INSTALL_RKE2_TYPE=server
-$ export INSTALL_RKE2_VERSION=<wanted version here>
-$ curl -sfL https://get.rke2.io | sh -
-$ systemctl enable --now rke2-server.service
+export INSTALL_RKE2_TYPE=server
+export INSTALL_RKE2_VERSION=<wanted version here>
+curl -sfL https://get.rke2.io | sh -
+sudo systemctl enable --now rke2-server.service
 ----
 
 * Connect to the nodes dedicated as workers of the RKE 2 cluster:
 
+[source, bash]
 ----
-$ export INSTALL_RKE2_TYPE=agent
-$ export INSTALL_RKE2_VERSION=<wanted version here>
-$ curl -sfL https://get.rke2.io | sh -
-$ systemctl enable --now rke2-agent.service
+export INSTALL_RKE2_TYPE=agent
+export INSTALL_RKE2_VERSION=<wanted version here>
+curl -sfL https://get.rke2.io | sh -
+sudo systemctl enable --now rke2-agent.service
 ----
 
 * More details can be found in the RKE 2 documentation:
@@ -154,8 +161,13 @@ $ systemctl enable --now rke2-agent.service
 * After the deployment of the RKE 2 cluster, check the availability of the storage class 
 vsphere-csi-sc which should have been created.
 
+[source, bash]
 ----
-$ kubectl get sc
+kubectl get sc
+----
+
+[source, bash]
+----
 NAME                       PROVISIONER              RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 vsphere-csi-sc (default)   csi.vsphere.vmware.com   Delete          Immediate           false                  17m
 ----


### PR DESCRIPTION
After repeatedly receiving feedback about the $ and # annotations in the SAP EIC guides, we decided to change this.
From now on, commands that require to be run as root will start with **sudo** while commands that can be run as any user won't have a prefix any longer.

The advantage of this is, that users can copy & paste commands from the best practices without the need to edit the line before execution.