### PR TITLE
Fix several references to documents for earlier service packs

### DIFF
--- a/adoc/SLES4SAP-HANAonKVM-15SP7.adoc
+++ b/adoc/SLES4SAP-HANAonKVM-15SP7.adoc
@@ -60,7 +60,7 @@ libvirt:: A management interface for KVM.
 qemu:: The virtual machine emulator, also seen as process on the hypervisor running the VM.
 SI units:: Some commands and configurations use the decimal prefix (for example GB), while other use the binary prefix (for example GiB). In this document we use the binary prefix where possible.
 
-For a general overview of the technical components of the KVM architecture, refer to section https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-kvm-intro.html["Introduction to KVM Virtualization"] of the Virtualization Guide.
+For a general overview of the technical components of the KVM architecture, refer to section https://documentation.suse.com/sles/15-SP7/html/SLES-all/cha-kvm-intro.html["Introduction to KVM Virtualization"] of the Virtualization Guide.
 
 [[_sec_sap_hana_virtualization_scenarios]]
 === SAP HANA virtualization scenarios
@@ -170,7 +170,10 @@ no
 Check the following SAP Notes for the latest details of supported SAP HANA on KVM scenarios:
 
 * {launchPadNotes}2284516[SAP Note 2284516 - "SAP HANA virtualized on SUSE Linux Enterprise Hypervisors"]
+* {launchPadNotes}3741904[SAP Note 3741904 - "SAP HANA on SUSE KVM Virtualization with SLES 15 SP7"]
 * {launchPadNotes}3538596[SAP Note 3538596 - "SAP HANA on SUSE KVM Virtualization with SLES 15 SP5"]
+* {launchPadNotes}3366235[SAP Note 3366235 - "SAP HANA on SUSE KVM Virtualization with SLES 15 SP4"]
+* {launchPadNotes}3120786[SAP Note 3120786 - "SAP HANA on SUSE KVM Virtualization with SLES 15 SP2"]
 
 [[_sec_sizing]]
 === Sizing
@@ -329,7 +332,7 @@ The following sections describe how to set up and configure the hypervisor for a
 [[_sec_kvm_hypervisor_installation]]
 === Installing the KVM hypervisor 
 
-For details, refer to section 6 https://documentation.suse.com/sles/15-SP5/single-html/SLES-virtualization/#cha-vt-installation[Installation of Virtualization Components] of the SUSE Virtualization Guide.
+For details, refer to section 6 https://documentation.suse.com/sles/15-SP7/single-html/SLES-virtualization/#cha-vt-installation[Installation of Virtualization Components] of the SUSE Virtualization Guide.
 
 This guide assumes that there is a bare installation of {sles4sap} available on the system. For installation instructions on {sles4sap}, refer to the https://documentation.suse.com/sles/15-SP7/html/SLES-all/article-installation.html["SUSE Linux Enterprise Server 15 SP7 Installation Quick Start Guide"]
 
@@ -391,8 +394,8 @@ If such line is not present, it might be the case that SR-IOV needs to be explic
 ===== Preparing a Virtual Function (VF) for a guest VM
 
 After checking that the NIC is SR-IOV capable, the host and the guest VM should be configured to use one of the available Virtual Functions (VFs) as (one of) the guest VM's network device(s).
-Find more information about SR-IOV as a technology and how to properly configure everything necessary for it to work well in the general case in the https://documentation.suse.com/sles/15-SP4/html/SLES-all/book-virtualization.html[SUSE Virtualization Guide for SUSE Linux Enterprise Server 15 SP4].
-Specifically, have a look here at the section https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-libvirt-config-virsh.html#sec-libvirt-config-io[Adding SR-IOV Devices].
+Find more information about SR-IOV as a technology and how to properly configure everything necessary for it to work well in the general case in the https://documentation.suse.com/sles/15-SP7/html/SLES-all/book-virtualization.html[SUSE Virtualization Guide for SUSE Linux Enterprise Server 15 SP7].
+Specifically, have a look here at the section https://documentation.suse.com/sles/15-SP7/html/SLES-all/cha-libvirt-config-virsh.html#sec-libvirt-config-io[Adding SR-IOV Devices].
 
 
 *Enabling PCI passthrough for the host kernel*
@@ -1221,7 +1224,7 @@ Note that this is a requirement for making it possible to load and use the "`cpu
 [[_sec_install_sles_for_sap_inside_the_guest_vm]]
 === Installing SUSE Linux Enterprise Server for SAP applications inside the Guest VM
 
-Refer to the https://documentation.suse.com/sles-sap/15-SP5/[SUSE Guide "`SUSE Linux Enterprise Server for SAP applications 15 SP4].
+Refer to the https://documentation.suse.com/sles-sap/15-SP7/[SUSE Guide "`SUSE Linux Enterprise Server for SAP applications 15 SP7].
           
 
 [[_sec_guest_operating_system_configuration_for_sap_hana]]
@@ -2405,8 +2408,8 @@ Note that this file is abridged for clarity; the cut is denoted by a `[...]` mar
 === Resources
 
 * https://documentation.suse.com/sbp-supported.html[SUSE Best Practices]
-* https://documentation.suse.com/sles/15-SP7/html/SLES-all/article-virtualization-best-practices.html[SUSE Virtualization Guide for SUSE Linux Enterprise Server 15 SP5]
-* {launchPadNotes}3538596[SAP Note 3538596 - "SAP HANA on SUSE KVM Virtualization with SLES 15 SP5"]
+* https://documentation.suse.com/sles/15-SP7/html/SLES-all/article-virtualization-best-practices.html[SUSE Virtualization Guide for SUSE Linux Enterprise Server 15 SP7]
+* {launchPadNotes}3741904[SAP Note 3741904 - "SAP HANA on SUSE KVM Virtualization with SLES 15 SP7"]
 * {launchPadNotes}2284516[SAP Note 2284516 - "SAP HANA virtualized on SUSE Linux Enterprise Hypervisors"]
 * {launchPadNotes}1944799[SAP Note 1944799 - "SAP HANA Guidelines for SLES Operating System Installation"]
 * {launchPadNotes}2684254[SAP Note 2684254 - "SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP"] 


### PR DESCRIPTION
I found references to the Virtualization Guide for previous SPs, and also SAP Notes for the previous SPs. 
I replaced them with the references to SP7-related documents. Please double check.